### PR TITLE
ホーム画面修正

### DIFF
--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -332,35 +332,6 @@ class _HomePageState extends ConsumerState<HomePage> {
   }
 }
 
-class _CategoryButton extends StatelessWidget {
-  const _CategoryButton({required this.label, required this.onPressed});
-
-  final String label;
-  final VoidCallback onPressed;
-
-  @override
-  Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: onPressed, // タップされたときに onPressed を呼び出す
-      child: Container(
-        decoration: BoxDecoration(
-          color: const Color(0xFFD9D9D9),
-          borderRadius: BorderRadius.circular(15), // 角を丸くする
-        ),
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-        child: Text(
-          label,
-          style: const TextStyle(
-            fontSize: 16,
-            fontWeight: FontWeight.bold,
-            color: Colors.black,
-          ),
-        ),
-      ),
-    );
-  }
-}
-
 class _MyRotatingButton extends StatefulWidget {
   // コンテナの表示状態を通知するためのコールバック
 

--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -1,7 +1,5 @@
 import 'dart:math' as math;
 
-//import 'package:firebase_auth/firebase_auth.dart';
-//import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -299,7 +299,7 @@ class _HomePageState extends ConsumerState<HomePage> {
                 ),
                 borderRadius: BorderRadius.circular(8),              ),
               child:const Padding(
-                padding: EdgeInsets.all(8.0),
+                padding: EdgeInsets.all(8),
                 child: Text(
                   '※ 3分程、時間がかかります。'
                       '\n※ 読み込み中はアプリをバックグラウンドに残してください。'

--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -1,6 +1,7 @@
 import 'dart:math' as math;
 
 import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
@@ -140,12 +141,12 @@ class _HomePageState extends ConsumerState<HomePage> {
                   visible: _isContainerVisible,
                   child: Positioned(
                     top: (MediaQuery.of(context).size.height - 327) /
-                        2, // 縦方向中央に配置
+                        4, // 縦方向中央に配置
                     left: (MediaQuery.of(context).size.width - 317) /
                         2, // 横方向中央に配置
                     child: Container(
                       width: 317, // 長方形の枠の幅を317に設定
-                      height: 327, // 長方形の枠の高さを327に設定
+                      height: 512, // 長方形の枠の高さを327に設定
                       decoration: BoxDecoration(
                         color: Colors.white.withOpacity(0.88),
                         borderRadius: BorderRadius.circular(30), // 角を丸くする
@@ -213,13 +214,100 @@ class _HomePageState extends ConsumerState<HomePage> {
       children: [
         const SizedBox(
           width: 250, // テキストの枠の幅を250に設定
-          child: Center(
-            child: Text(
-              '以下のボタンを押すと、Google Photoの画像から\n料理の画像のみを判別して\nダウンロードできます！',
-              textAlign: TextAlign.left,
-              style: TextStyle(
-                fontSize: 20,
-                fontWeight: FontWeight.bold,
+          child: Padding(
+            padding: EdgeInsets.only(top: 5.0),
+            child:Center(
+              child: Text(
+                'あなたのGoogle Photosから自動で食べ物の写真を読み込みます。',
+                textAlign: TextAlign.left,
+                style: TextStyle(
+                  fontSize: 16,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(
+          width: 250, // テキストの枠の幅を250に設定
+          child: Padding(
+            padding: EdgeInsets.only(top: 5.0),
+            child:Center(
+              child: Text(
+                '読み込まれた画像は順次ホーム画面に表示されます。',
+                textAlign: TextAlign.left,
+                style: TextStyle(
+                  fontSize: 16,
+                ),
+              ),
+            ),
+          ),
+        ),
+        const SizedBox(
+          width: 260, // テキストの枠の幅を250に設定
+          child: Padding(
+            padding: EdgeInsets.only(top: 30.0),
+              child:Row(
+                children: <Widget>[
+                  SizedBox(
+                    width: 50, // テキストの枠の幅を250に設定
+                    child: Padding(
+                      padding: EdgeInsets.only(top: 5.0),
+                      child:Center(
+                        child: Text(
+                          '注意点',
+                          textAlign: TextAlign.left,
+                          style: TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                            color: Color(0xFFEF913A),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  SizedBox(
+                    width: 150, // テキストの枠の幅を250に設定
+                    child: Padding(
+                      padding: EdgeInsets.only(top: 5.0),
+                      child:Center(
+                        child: Text(
+                          '必ずご確認ください',
+                          textAlign: TextAlign.left,
+                          style: TextStyle(
+                            fontSize: 12,
+                            color: Color(0xFFEF913A),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+          ),
+        ),
+        SizedBox(
+          width: 265, // テキストの枠の幅を250に設定
+          child: Padding(
+            padding: const EdgeInsets.only(top: 5.0),
+            child:Card(
+              color: const Color(0xFFFFE8DB),
+              shape: RoundedRectangleBorder(
+                side: const BorderSide(
+                  color: Color(0xFFEF913A), //色
+                  width: 2, //太さ
+                ),
+                borderRadius: BorderRadius.circular(8),              ),
+              child:const Padding(
+                padding: EdgeInsets.all(8.0),
+                child: Text(
+                  '※ 3分程、時間がかかります。\n※ 読み込み中はアプリをバックグラウンドに残してください。\n完全に閉じないでください。\n(他のアプリを使用しても問題ありません。)',
+                  textAlign: TextAlign.left,
+                  style: TextStyle(
+                    fontSize: 14,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
               ),
             ),
           ),
@@ -235,11 +323,11 @@ class _HomePageState extends ConsumerState<HomePage> {
             minimumSize: const Size(250, 50),
           ),
           child: const Text(
-            '画像を読み込む  1/2',
+            '画像読み込みを開始する',
             style: TextStyle(
               fontSize: 20,
               fontWeight: FontWeight.bold,
-              color: Colors.black,
+              color: Colors.white,
             ),
           ),
         ),
@@ -257,9 +345,9 @@ class _HomePageState extends ConsumerState<HomePage> {
             child: isLoading
                 ? const Text(
                     // ignore: lines_longer_than_80_chars
-                    '画像を処理中です...\n10分ほどお待ちください。\n他のアプリに切り替えても大丈夫です。\n完了すると通知でお知らせします',
+                    '画像を読み込み中です...',
                     style: TextStyle(
-                      fontSize: 20,
+                      fontSize: 16,
                       fontWeight: FontWeight.bold,
                     ),
                   )
@@ -268,16 +356,16 @@ class _HomePageState extends ConsumerState<HomePage> {
                         final status = authedUser.classifyPhotosStatus;
                         if (status == ClassifyPhotosStatus.readyForUse) {
                           return const Text(
-                            '処理が完了しました！\n下記から画像をダウンロードできます！',
+                            '初期表示用の画像の読み込みが完了しました。\n下記ボタンから、画像をダウンロードしてください。',
                             style: TextStyle(
-                              fontSize: 20,
+                              fontSize: 16,
                               fontWeight: FontWeight.bold,
                             ),
                           );
                         } else if (status == ClassifyPhotosStatus.processing) {
                           return const Text(
                             // ignore: lines_longer_than_80_chars
-                            '画像を処理中です...\n10分ほどお待ちください。\n他のアプリに切り替えても大丈夫です。\n完了すると通知でお知らせします',
+                            '画像を処理中です...\n3分ほどお待ちください。\n他のアプリに切り替えても大丈夫です。\n完了すると通知でお知らせします',
                             style: TextStyle(
                               fontSize: 20,
                               fontWeight: FontWeight.bold,
@@ -319,7 +407,7 @@ class _HomePageState extends ConsumerState<HomePage> {
           ),
           child: const Text(
             // MEMO(masaki): ステップの2/2というのを伝わりやすいUIに改修
-            'ダウンロード 2/2',
+            'ダウンロードする',
             style: TextStyle(
               fontSize: 20,
               fontWeight: FontWeight.bold,

--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -104,20 +104,6 @@ class _HomePageState extends ConsumerState<HomePage> {
     return Stack(
       children: [
         Scaffold(
-          // TODO(masaki): ログアウト機能実装後 or 不要になったタイミングで削除
-          floatingActionButton: Visibility(
-            visible: _isContainerVisible,
-            child: FloatingActionButton(
-              onPressed: () {
-                FirebaseAuth.instance.signOut();
-              },
-              child: const Icon(
-                Icons.logout,
-                color: Colors.black,
-                size: 40,
-              ),
-            ),
-          ),
           body: SafeArea(
             child: Stack(
               children: [
@@ -401,23 +387,23 @@ class _MyRotatingButtonState extends State<_MyRotatingButton> {
   @override
   Widget build(BuildContext context) {
     return Positioned(
-      top: (MediaQuery.of(context).size.height - 327) / 2 + 405,
-      left: (MediaQuery.of(context).size.width - 60) / 2,
+      top: (MediaQuery.of(context).size.height - 327) / 2 + 442,
+      left: MediaQuery.of(context).size.width - 75,
       child: Container(
         width: 60,
         height: 60,
         decoration: const BoxDecoration(
-          color: Colors.black,
+          color: Color(0xFFEF913A),
           shape: BoxShape.circle,
         ),
         child: InkWell(
           onTap: _toggleRotation, // タップ時に回転を切り替える
           child: Center(
             child: Transform.rotate(
-              angle: _isRotated ? 0 : 45 * (math.pi / 180), // フラグに基づいて角度を決定
+              angle: _isRotated ? 0 : math.pi / 180, // フラグに基づいて角度を決定
               child: const Icon(
                 Icons.add,
-                color: Color(0xFFEF913A),
+                color: Colors.black,
                 size: 40,
               ),
             ),

--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -1,7 +1,7 @@
 import 'dart:math' as math;
 
-import 'package:firebase_auth/firebase_auth.dart';
-import 'package:flutter/cupertino.dart';
+//import 'package:firebase_auth/firebase_auth.dart';
+//import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -301,7 +301,9 @@ class _HomePageState extends ConsumerState<HomePage> {
               child:const Padding(
                 padding: EdgeInsets.all(8.0),
                 child: Text(
-                  '※ 3分程、時間がかかります。\n※ 読み込み中はアプリをバックグラウンドに残してください。\n完全に閉じないでください。\n(他のアプリを使用しても問題ありません。)',
+                  '※ 3分程、時間がかかります。'
+                      '\n※ 読み込み中はアプリをバックグラウンドに残してください。'
+                      '完全に閉じないでください。(他のアプリを使用しても問題ありません。)',
                   textAlign: TextAlign.left,
                   style: TextStyle(
                     fontSize: 14,

--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -127,34 +127,6 @@ class _HomePageState extends ConsumerState<HomePage> {
                   color: Colors.black,
                   child: Column(
                     children: [
-                      Padding(
-                        padding: const EdgeInsets.all(16),
-                        child: Row(
-                          mainAxisAlignment: MainAxisAlignment.spaceAround,
-                          children: [
-                            _CategoryButton(
-                              label: 'ラーメン',
-                              onPressed: () => _downloadPhotos('ramen', ref),
-                            ),
-                            _CategoryButton(
-                              label: 'カフェ',
-                              onPressed: () => _downloadPhotos('cafe', ref),
-                            ),
-                            _CategoryButton(
-                              label: '和食',
-                              onPressed: () =>
-                                  _downloadPhotos('japanese_food', ref),
-                            ),
-                            _CategoryButton(
-                              label: 'その他',
-                              onPressed: () => _downloadPhotos(
-                                'international_cuisine',
-                                ref,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
                       Expanded(
                         child: GridView.builder(
                           gridDelegate:

--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -215,7 +215,7 @@ class _HomePageState extends ConsumerState<HomePage> {
         const SizedBox(
           width: 250, // テキストの枠の幅を250に設定
           child: Padding(
-            padding: EdgeInsets.only(top: 5.0),
+            padding: EdgeInsets.only(top: 5),
             child:Center(
               child: Text(
                 'あなたのGoogle Photosから自動で食べ物の写真を読み込みます。',
@@ -231,7 +231,7 @@ class _HomePageState extends ConsumerState<HomePage> {
         const SizedBox(
           width: 250, // テキストの枠の幅を250に設定
           child: Padding(
-            padding: EdgeInsets.only(top: 5.0),
+            padding: EdgeInsets.only(top: 5),
             child:Center(
               child: Text(
                 '読み込まれた画像は順次ホーム画面に表示されます。',
@@ -246,13 +246,13 @@ class _HomePageState extends ConsumerState<HomePage> {
         const SizedBox(
           width: 260, // テキストの枠の幅を250に設定
           child: Padding(
-            padding: EdgeInsets.only(top: 30.0),
+            padding: EdgeInsets.only(top: 30),
               child:Row(
                 children: <Widget>[
                   SizedBox(
                     width: 50, // テキストの枠の幅を250に設定
                     child: Padding(
-                      padding: EdgeInsets.only(top: 5.0),
+                      padding: EdgeInsets.only(top: 5),
                       child:Center(
                         child: Text(
                           '注意点',
@@ -269,7 +269,7 @@ class _HomePageState extends ConsumerState<HomePage> {
                   SizedBox(
                     width: 150, // テキストの枠の幅を250に設定
                     child: Padding(
-                      padding: EdgeInsets.only(top: 5.0),
+                      padding: EdgeInsets.only(top: 5),
                       child:Center(
                         child: Text(
                           '必ずご確認ください',
@@ -289,7 +289,7 @@ class _HomePageState extends ConsumerState<HomePage> {
         SizedBox(
           width: 265, // テキストの枠の幅を250に設定
           child: Padding(
-            padding: const EdgeInsets.only(top: 5.0),
+            padding: const EdgeInsets.only(top: 5),
             child:Card(
               color: const Color(0xFFFFE8DB),
               shape: RoundedRectangleBorder(


### PR DESCRIPTION
- ジャンルごとのタブを無くす
- ログアウトボタンの代わりにフローティングアクションボタン部分からダイアログを表示するようにする
- ダイアログのUIをFigmaに合わせる
    - 文言修正
<table>
<thead>
<tr>
<td>android</td>
</tr>
</thead>
<tr>
<td><img src="https://github.com/schwarzwald0906/My_Gourmet/assets/57353856/f3010052-2c6f-437a-9a1c-f170185bd3e7" width="200"></td>
</tr>
<tr>
</table> 