### PR TITLE
写真読み込みダイアログ関連の修正

### DIFF
--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -130,7 +130,9 @@ class _HomePageState extends ConsumerState<HomePage> {
                   onPressed: () => setState(() {
                     _isContainerVisible = !_isContainerVisible;
                   }),
-                  child: const Icon(Icons.add),
+                  child: _isContainerVisible
+                      ? const Icon(Icons.close, size: 22)
+                      : const Icon(Icons.add),
                 ),
                 body: SafeArea(
                   child: Stack(
@@ -165,21 +167,48 @@ class _HomePageState extends ConsumerState<HomePage> {
                               4, // 縦方向中央に配置
                           left: (MediaQuery.of(context).size.width - 317) /
                               2, // 横方向中央に配置
-                          child: Container(
-                            width: 317, // 長方形の枠の幅を317に設定
-                            height: 457, // 長方形の枠の高さを327に設定
-                            decoration: BoxDecoration(
-                              color: Colors.white.withOpacity(0.88),
-                              borderRadius: BorderRadius.circular(30), // 角を丸くする
-                            ),
-                            child: PageView(
-                              physics: const NeverScrollableScrollPhysics(),
-                              controller: _pageController,
-                              children: [
-                                _buildFirstPage(),
-                                _buildSecondPage(),
-                              ],
-                            ),
+                          child: Stack(
+                            children: [
+                              Container(
+                                width: 317, // 長方形の枠の幅を317に設定
+                                height: 457, // 長方形の枠の高さを327に設定
+                                decoration: BoxDecoration(
+                                  color: Colors.white.withOpacity(0.88),
+                                  borderRadius:
+                                      BorderRadius.circular(24), // 角を丸くする
+                                ),
+                                child: PageView(
+                                  physics: const NeverScrollableScrollPhysics(),
+                                  controller: _pageController,
+                                  children: [
+                                    _buildFirstPage(),
+                                    _buildSecondPage(),
+                                  ],
+                                ),
+                              ),
+                              Positioned(
+                                top: 16,
+                                right: 16,
+                                child: Container(
+                                  width: 32,
+                                  height: 32,
+                                  decoration: BoxDecoration(
+                                    color: Themes.gray[50],
+                                    borderRadius:
+                                        BorderRadius.circular(24), // 角を丸くする
+                                  ),
+                                  child: IconButton(
+                                    padding: EdgeInsets.zero,
+                                    icon: const Icon(Icons.close),
+                                    onPressed: () {
+                                      setState(() {
+                                        _isContainerVisible = false;
+                                      });
+                                    },
+                                  ),
+                                ),
+                              ),
+                            ],
                           ),
                         ),
                       ),

--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -173,6 +173,7 @@ class _HomePageState extends ConsumerState<HomePage> {
                               borderRadius: BorderRadius.circular(30), // 角を丸くする
                             ),
                             child: PageView(
+                              physics: const NeverScrollableScrollPhysics(),
                               controller: _pageController,
                               children: [
                                 _buildFirstPage(),


### PR DESCRIPTION
## 概要

ミーティング時に少しお話しした、写真のリストの上に重なるコンテナ(ダイアログ？)周りの小さいレイアウト修正です。

## 変更点

・stateによって出し分ける画面がスワイプできてしまうのを修正
・ダイアログが出ている間はFloatingActionButtonのアイコンを✖︎に
・ダイアログ右上に閉じるボタンを追加

<img  width="300" src="https://github.com/schwarzwald0906/My_Gourmet/assets/80320123/d71dfa26-a5fd-4948-8522-01f74a0f9605">
