### PR TITLE
readyForUseの状態に応じて画面を更新(TAS-101)

### DIFF
--- a/lib/features/auth/auth_controller.dart
+++ b/lib/features/auth/auth_controller.dart
@@ -35,7 +35,7 @@ final authedUserStreamProvider = StreamProvider.autoDispose<AuthedUser>(
 
 final authControllerProvider = Provider<AuthController>(AuthController.new);
 
-/// [AuthRepository]の書き込み用クラス
+/// [AuthRepository]を経由して外部通信の操作を担当するコントローラー
 class AuthController {
   AuthController(this._ref);
 
@@ -46,5 +46,10 @@ class AuthController {
   /// ユーザーアカウント削除用メソッド
   Future<void> deleteUserAccount() async {
     await _authRepository.deleteUserAccount();
+  }
+
+  /// サインイン用メソッド
+  Future<({String accessToken, String userId})> signInWithGoogle() async {
+    return _authRepository.signInWithGoogle();
   }
 }

--- a/lib/features/photo/photo_controller.dart
+++ b/lib/features/photo/photo_controller.dart
@@ -24,19 +24,14 @@ class PhotoController {
   /// 写真アップロード用メソッド
   ///
   /// サインインをした上でfirestore上で状態管理し、写真アップロード用のCFを起動する。
-  Future<void> uploadPhotos({required String? userId}) async {
-    // TODO(masaki): ログインしているユーザーに関しては、
-    //  リフレッシュトークンを用いてアクセストークンを再生成してログインを不要に出来ないか確認
-    // if (userId != null) {
-    //   // 更新処理
-    //   return;
-    // }
-
-    final result = await _authRepository.signInWithGoogle();
-    await _authRepository.upsertClassifyPhotosStatus(result.userId);
+  Future<void> uploadPhotos({
+    required String accessToken,
+    required String userId,
+  }) async {
+    await _authRepository.upsertClassifyPhotosStatus(userId);
     await _photoRepository.callClassifyPhotos(
-      result.accessToken,
-      result.userId,
+      accessToken,
+      userId,
     );
   }
 

--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -373,14 +373,31 @@ class _HomePageState extends ConsumerState<HomePage> {
                   )
                 : ref.watch(authedUserStreamProvider).when(
                       data: (authedUser) {
+                        // TODO(masaki): 初回読み込み時のreadyForUseが一瞬画面に反映されてしまうので、全体的に見直す
                         final status = authedUser.classifyPhotosStatus;
                         if (status == ClassifyPhotosStatus.readyForUse) {
-                          return const Text(
-                            '初期表示用の画像の読み込みが完了しました。\n下記ボタンから、画像をダウンロードしてください。',
-                            style: TextStyle(
-                              fontSize: 16,
-                              fontWeight: FontWeight.bold,
-                            ),
+                          return Column(
+                            children: [
+                              const Text(
+                                '初期表示用の画像の読み込みが完了しました。\n下記ボタンから、画像をダウンロードしてください。',
+                                style: TextStyle(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                              const Gap(48),
+                              ElevatedButton(
+                                onPressed: () {
+                                  _downloadPhotos(ref);
+                                },
+                                child: const Text(
+                                  'ダウンロードする',
+                                  style: TextStyle(
+                                    fontWeight: FontWeight.bold,
+                                  ),
+                                ),
+                              ),
+                            ],
                           );
                         } else if (status == ClassifyPhotosStatus.processing) {
                           return const Column(
@@ -419,22 +436,6 @@ class _HomePageState extends ConsumerState<HomePage> {
                     ),
           ),
         ),
-        const SizedBox(height: 30), // スペースを設定
-        if (!isLoading)
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16),
-            child: ElevatedButton(
-              onPressed: () {
-                _downloadPhotos(ref);
-              },
-              child: const Text(
-                'ダウンロードする',
-                style: TextStyle(
-                  fontWeight: FontWeight.bold,
-                ),
-              ),
-            ),
-          ),
       ],
     );
   }

--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -85,9 +85,16 @@ class _HomePageState extends ConsumerState<HomePage> {
     });
 
     try {
-      await ref
-          .read(photoControllerProvider)
-          .uploadPhotos(userId: ref.watch(userIdProvider));
+      final result = await ref.read(authControllerProvider).signInWithGoogle();
+
+      setState(() {
+        isLoading = false;
+      });
+
+      await ref.read(photoControllerProvider).uploadPhotos(
+            accessToken: result.accessToken,
+            userId: result.userId,
+          );
     } on Exception catch (e) {
       // 例外が発生した場合、エラーメッセージを表示
       if (context.mounted) {
@@ -95,9 +102,8 @@ class _HomePageState extends ConsumerState<HomePage> {
           SnackBar(content: Text(e.toString())),
         );
       }
-    } finally {
       setState(() {
-        isLoading = false; // 非同期処理が完了したら、isLoadingをfalseに設定
+        isLoading = false;
       });
     }
   }
@@ -377,13 +383,19 @@ class _HomePageState extends ConsumerState<HomePage> {
                             ),
                           );
                         } else if (status == ClassifyPhotosStatus.processing) {
-                          return const Text(
-                            // ignore: lines_longer_than_80_chars
-                            '画像を処理中です...\n3分ほどお待ちください。\n他のアプリに切り替えても大丈夫です。\n完了すると通知でお知らせします',
-                            style: TextStyle(
-                              fontSize: 20,
-                              fontWeight: FontWeight.bold,
-                            ),
+                          return const Column(
+                            children: [
+                              Text(
+                                // ignore: lines_longer_than_80_chars
+                                '画像を処理中です...\n3分ほどお待ちください。\n他のアプリに切り替えても大丈夫です。\n完了すると通知でお知らせします',
+                                style: TextStyle(
+                                  fontSize: 20,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                              Gap(16),
+                              CircularProgressIndicator(),
+                            ],
                           );
                         } else {
                           // TODO(masaki): エラーハンドリング

--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -373,12 +373,14 @@ class _HomePageState extends ConsumerState<HomePage> {
                   )
                 : ref.watch(authedUserStreamProvider).when(
                       data: (authedUser) {
-                        // TODO(masaki): 初回読み込み時のreadyForUseが一瞬画面に反映されてしまうので、全体的に見直す
+                        // TODO(masaki): 初回読み込み時のreadyForUseが一瞬画面に反映されてしまうので、
+                        //  全体的に見直す
                         final status = authedUser.classifyPhotosStatus;
                         if (status == ClassifyPhotosStatus.readyForUse) {
                           return Column(
                             children: [
                               const Text(
+                                // ignore: lines_longer_than_80_chars
                                 '初期表示用の画像の読み込みが完了しました。\n下記ボタンから、画像をダウンロードしてください。',
                                 style: TextStyle(
                                   fontSize: 16,


### PR DESCRIPTION
# issue
https://www.notion.so/masakisato/8-flutter-e9584b85d8634b76a46c103bbc76cdee?pvs=25

# 対応したこと
取り急ぎ、緊急度高い以下の問題を解消しました：
- ダウンロード許可の状態を、APIのレスポンス受け取り時→readyForUseへの更新時へ変更
[listen to readyForUse status](https://github.com/schwarzwald0906/My_Gourmet/commit/cace0b87d7e2d619a97984247862fa7ed36a2598)

- ダウンロードボタンの表示を上記のタイミングまで表示しない
[hide the download button when not available](https://github.com/schwarzwald0906/My_Gourmet/commit/19d7113752e1ce2ca9ea951cc5e9e8e90db7cdda)

# 実際の挙動

https://github.com/schwarzwald0906/My_Gourmet/assets/60085207/4f060116-4a54-404d-8b87-45515f7b4be2


一瞬の状態のちらつき（アプリ起動後の初回には起こり得ないはず）、や文言の修正など、細かい点含めた諸々は、また別途以下issueで対応します
https://www.notion.so/masakisato/933dc03693d643e9b6e34343f7ff5512?pvs=4

