### PR TITLE
写真保存機能追加

### DIFF
--- a/android/app/src/debug/AndroidManifest.xml
+++ b/android/app/src/debug/AndroidManifest.xml
@@ -4,4 +4,7 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,5 +1,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-<uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+
     <application
             android:label="@string/app_name"
         android:name="${applicationName}"

--- a/android/app/src/profile/AndroidManifest.xml
+++ b/android/app/src/profile/AndroidManifest.xml
@@ -4,4 +4,7 @@
          to allow setting breakpoints, to provide hot reload, etc.
     -->
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
 </manifest>

--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -1,0 +1,53 @@
+import 'dart:io';
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:path/path.dart';
+import 'package:path_provider/path_provider.dart';
+
+part 'database.g.dart';
+
+/// 写真テーブル
+@DataClassName('Photo')
+@TableIndex(name: 'photo_id', columns: {#id})
+@TableIndex(name: 'photo_is_food', columns: {#isFood})
+class Photos extends Table {
+  // IntColumn get id => integer().autoIncrement()();
+
+  /// 写真のid
+  TextColumn get id => text().unique()();
+
+  /// 写真のパス
+  TextColumn get path => text()();
+
+// DateTimeColumn get date => dateTime()();
+  /// 食べ物かどうか
+  BoolColumn get isFood => boolean()();
+}
+
+/// DB設定
+@DriftDatabase(tables: [Photos])
+class AppDatabase extends _$AppDatabase {
+  // 引数なしのコンストラクタで_openConnectionを直接使用
+  AppDatabase() : super(_openConnection());
+
+  @override
+  int get schemaVersion => 1;
+}
+
+/// コネクション生成
+LazyDatabase _openConnection() {
+  return LazyDatabase(() async {
+    final dbFolder = await getApplicationDocumentsDirectory();
+    final file = File(join(dbFolder.path, 'db.sqlite'));
+    return NativeDatabase(file);
+  });
+}
+
+/// DBインスタンス生成
+final AppDatabase appDatabase = AppDatabase();
+
+/// DBインスタンス取得
+AppDatabase getAppDatabaseInstance() {
+  return appDatabase;
+}

--- a/lib/core/database/database.g.dart
+++ b/lib/core/database/database.g.dart
@@ -1,0 +1,245 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'database.dart';
+
+// ignore_for_file: type=lint
+class $PhotosTable extends Photos with TableInfo<$PhotosTable, Photo> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $PhotosTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+      'id', aliasedName, false,
+      type: DriftSqlType.string,
+      requiredDuringInsert: true,
+      defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'));
+  static const VerificationMeta _pathMeta = const VerificationMeta('path');
+  @override
+  late final GeneratedColumn<String> path = GeneratedColumn<String>(
+      'path', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  static const VerificationMeta _isFoodMeta = const VerificationMeta('isFood');
+  @override
+  late final GeneratedColumn<bool> isFood = GeneratedColumn<bool>(
+      'is_food', aliasedName, false,
+      type: DriftSqlType.bool,
+      requiredDuringInsert: true,
+      defaultConstraints:
+          GeneratedColumn.constraintIsAlways('CHECK ("is_food" IN (0, 1))'));
+  @override
+  List<GeneratedColumn> get $columns => [id, path, isFood];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'photos';
+  @override
+  VerificationContext validateIntegrity(Insertable<Photo> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    } else if (isInserting) {
+      context.missing(_idMeta);
+    }
+    if (data.containsKey('path')) {
+      context.handle(
+          _pathMeta, path.isAcceptableOrUnknown(data['path']!, _pathMeta));
+    } else if (isInserting) {
+      context.missing(_pathMeta);
+    }
+    if (data.containsKey('is_food')) {
+      context.handle(_isFoodMeta,
+          isFood.isAcceptableOrUnknown(data['is_food']!, _isFoodMeta));
+    } else if (isInserting) {
+      context.missing(_isFoodMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => const {};
+  @override
+  Photo map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return Photo(
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}id'])!,
+      path: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}path'])!,
+      isFood: attachedDatabase.typeMapping
+          .read(DriftSqlType.bool, data['${effectivePrefix}is_food'])!,
+    );
+  }
+
+  @override
+  $PhotosTable createAlias(String alias) {
+    return $PhotosTable(attachedDatabase, alias);
+  }
+}
+
+class Photo extends DataClass implements Insertable<Photo> {
+  /// 写真のid
+  final String id;
+
+  /// 写真のパス
+  final String path;
+
+  /// 食べ物かどうか
+  final bool isFood;
+  const Photo({required this.id, required this.path, required this.isFood});
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    map['path'] = Variable<String>(path);
+    map['is_food'] = Variable<bool>(isFood);
+    return map;
+  }
+
+  PhotosCompanion toCompanion(bool nullToAbsent) {
+    return PhotosCompanion(
+      id: Value(id),
+      path: Value(path),
+      isFood: Value(isFood),
+    );
+  }
+
+  factory Photo.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return Photo(
+      id: serializer.fromJson<String>(json['id']),
+      path: serializer.fromJson<String>(json['path']),
+      isFood: serializer.fromJson<bool>(json['isFood']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+      'path': serializer.toJson<String>(path),
+      'isFood': serializer.toJson<bool>(isFood),
+    };
+  }
+
+  Photo copyWith({String? id, String? path, bool? isFood}) => Photo(
+        id: id ?? this.id,
+        path: path ?? this.path,
+        isFood: isFood ?? this.isFood,
+      );
+  @override
+  String toString() {
+    return (StringBuffer('Photo(')
+          ..write('id: $id, ')
+          ..write('path: $path, ')
+          ..write('isFood: $isFood')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => Object.hash(id, path, isFood);
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      (other is Photo &&
+          other.id == this.id &&
+          other.path == this.path &&
+          other.isFood == this.isFood);
+}
+
+class PhotosCompanion extends UpdateCompanion<Photo> {
+  final Value<String> id;
+  final Value<String> path;
+  final Value<bool> isFood;
+  final Value<int> rowid;
+  const PhotosCompanion({
+    this.id = const Value.absent(),
+    this.path = const Value.absent(),
+    this.isFood = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  PhotosCompanion.insert({
+    required String id,
+    required String path,
+    required bool isFood,
+    this.rowid = const Value.absent(),
+  })  : id = Value(id),
+        path = Value(path),
+        isFood = Value(isFood);
+  static Insertable<Photo> custom({
+    Expression<String>? id,
+    Expression<String>? path,
+    Expression<bool>? isFood,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (path != null) 'path': path,
+      if (isFood != null) 'is_food': isFood,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  PhotosCompanion copyWith(
+      {Value<String>? id,
+      Value<String>? path,
+      Value<bool>? isFood,
+      Value<int>? rowid}) {
+    return PhotosCompanion(
+      id: id ?? this.id,
+      path: path ?? this.path,
+      isFood: isFood ?? this.isFood,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (path.present) {
+      map['path'] = Variable<String>(path.value);
+    }
+    if (isFood.present) {
+      map['is_food'] = Variable<bool>(isFood.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('PhotosCompanion(')
+          ..write('id: $id, ')
+          ..write('path: $path, ')
+          ..write('isFood: $isFood, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+abstract class _$AppDatabase extends GeneratedDatabase {
+  _$AppDatabase(QueryExecutor e) : super(e);
+  late final $PhotosTable photos = $PhotosTable(this);
+  late final Index photoId =
+      Index('photo_id', 'CREATE INDEX photo_id ON photos (id)');
+  late final Index photoIsFood =
+      Index('photo_is_food', 'CREATE INDEX photo_is_food ON photos (is_food)');
+  @override
+  Iterable<TableInfo<Table, Object?>> get allTables =>
+      allSchemaEntities.whereType<TableInfo<Table, Object?>>();
+  @override
+  List<DatabaseSchemaEntity> get allSchemaEntities =>
+      [photos, photoId, photoIsFood];
+}

--- a/lib/core/local_photo_repository.dart
+++ b/lib/core/local_photo_repository.dart
@@ -1,0 +1,45 @@
+import 'package:drift/drift.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:photo_manager/photo_manager.dart';
+import '../../core/database/database.dart';
+
+/// [LocalPhotoRepository]用プロバイダー
+final localPhotoRepositoryProvider =
+    Provider((ref) => LocalPhotoRepository._());
+
+/// DBを操作するクラス
+class LocalPhotoRepository {
+  LocalPhotoRepository._();
+
+  /// DBインスタンス生成
+  final AppDatabase db = AppDatabase();
+
+  /// 最後の写真データを取得する
+  Future<Photo?> getLastPhoto() async {
+    return (db.select(db.photos)
+          ..orderBy([
+            (t) => OrderingTerm(expression: t.id, mode: OrderingMode.desc),
+          ])
+          ..limit(1))
+        .getSingleOrNull();
+  }
+
+  /// 写真データを保存する
+  /// [photo] 写真データ
+  /// [isFood] 食べ物かどうか
+  Future<void> savePhoto({
+    required AssetEntity photo,
+    required bool isFood,
+  }) async {
+    final file = await photo.file;
+    if (file != null) {
+      final photoModel = PhotosCompanion(
+        id: Value(photo.id),
+        path: Value(file.path),
+        // date: Value(DateTime.now()),
+        isFood: Value(isFood),
+      );
+      await db.into(db.photos).insert(photoModel);
+    }
+  }
+}

--- a/lib/core/permission_service.dart
+++ b/lib/core/permission_service.dart
@@ -1,0 +1,34 @@
+import 'dart:io';
+
+import 'package:device_info_plus/device_info_plus.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+/// パーミッションエラー判定用クラス
+class PermissionException extends Error {}
+
+/// [PermissionService]用プロバイダー
+final permissionServiceProvider = Provider<PermissionService>(
+  (ref) => PermissionService._(),
+);
+
+/// [Permission]を操作するクラス
+class PermissionService {
+  PermissionService._();
+
+  /// 写真のパーミッションを取得する
+  Future<bool> getPhotoPermission() async {
+    if (Platform.isAndroid) {
+      final info = await DeviceInfoPlugin().androidInfo;
+
+      // sdkが33以上の場合
+      if (info.version.sdkInt >= 33) {
+        return (await Permission.photos.request()).isGranted;
+      }
+
+      return (await Permission.photos.request()).isGranted;
+    } else {
+      return (await Permission.photos.request()).isGranted;
+    }
+  }
+}

--- a/lib/core/photo_manager_service.dart
+++ b/lib/core/photo_manager_service.dart
@@ -51,7 +51,8 @@ class PhotoService {
       return [];
     }
 
-    final photos = await albums[0].getAssetListPaged(page: 0, size: 2);
+    // 100件取得(とりあえずの値なのであとで変更するかも)
+    final photos = await albums[0].getAssetListPaged(page: 0, size: 100);
 
     return photos;
   }

--- a/lib/core/photo_manager_service.dart
+++ b/lib/core/photo_manager_service.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:photo_manager/photo_manager.dart';
+
+import 'local_photo_repository.dart';
+
+/// [PhotoService]用プロバイダー
+final photoManagerServiceProvider = Provider<PhotoService>(
+  PhotoService._,
+);
+
+/// [PhotoManager]を操作するクラス
+class PhotoService {
+  PhotoService._(this.ref);
+
+  final Ref ref;
+
+  /// 写真取得
+  /// [lastId] 最後の写真id
+  Future<List<AssetEntity>> getAllPhotos({String? lastId}) async {
+    var filter = AdvancedCustomFilter().addWhereCondition(
+      // 画像でフィルタリング
+      ColumnWhereCondition(
+        column: CustomColumns.base.mediaType,
+        operator: '=',
+        value: '1',
+      ),
+    );
+
+    // 初回ロード
+    if (lastId == null) {
+      // DBから最後の写真データを取得
+      final lastPhoto =
+          await ref.read(localPhotoRepositoryProvider).getLastPhoto();
+
+      // 取得できた場合続きから写真を取得する
+      if (lastPhoto != null) {
+        filter = _getPhotoIdFilter(filter, lastPhoto.id);
+      }
+    } else {
+      filter = _getPhotoIdFilter(filter, lastId);
+    }
+
+    // 写真を古い順に取得
+    final albums = await PhotoManager.getAssetPathList(
+      filterOption: filter.addOrderBy(
+        column: CustomColumns.base.id,
+      ),
+    );
+
+    if (albums.isEmpty) {
+      return [];
+    }
+
+    final photos = await albums[0].getAssetListPaged(page: 0, size: 2);
+
+    return photos;
+  }
+
+  /// 写真idでフィルタリングする
+  /// [filter] フィルター
+  /// [lastId] 最後の写真id
+  AdvancedCustomFilter _getPhotoIdFilter(
+    AdvancedCustomFilter filter,
+    String lastId,
+  ) {
+    return filter.addWhereCondition(
+      ColumnWhereCondition(
+        column: CustomColumns.base.id,
+        operator: '>',
+        value: lastId,
+      ),
+    );
+  }
+}

--- a/lib/core/router.dart
+++ b/lib/core/router.dart
@@ -6,6 +6,7 @@ import 'package:go_router/go_router.dart';
 import '../view/home_page.dart';
 import '../view/my_page.dart';
 import '../view/root_page.dart';
+import '../view/swipe_photo_page.dart';
 import 'analytics_repository.dart';
 
 final routerProvider = Provider(
@@ -24,6 +25,11 @@ final routerProvider = Provider(
             name: MyPage.routeName,
             path: MyPage.routePath,
             builder: (context, state) => const MyPage(),
+          ),
+          GoRoute(
+            name: SwipePhotoPage.routeName,
+            path: SwipePhotoPage.routePath,
+            builder: (context, state) => const SwipePhotoPage(),
           ),
         ],
       ),

--- a/lib/features/swipe_photo/swipe_photo_controller.dart
+++ b/lib/features/swipe_photo/swipe_photo_controller.dart
@@ -1,0 +1,111 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:photo_manager/photo_manager.dart';
+
+import '../../core/local_photo_repository.dart';
+import '../../core/permission_service.dart';
+import '../../core/photo_manager_service.dart';
+
+/// 写真のインデックスを管理するProvider
+class _PhotoIndexNotifier extends AutoDisposeNotifier<int> {
+  @override
+  int build() => 0;
+
+  /// indexプラス
+  void increment() => state++;
+
+  /// indexクリア
+  void clear() => state = 0;
+}
+
+final photoIndexProvider =
+    NotifierProvider.autoDispose<_PhotoIndexNotifier, int>(
+  _PhotoIndexNotifier.new,
+);
+
+/// 写真を取得するProvider
+class _PhotoListNotifier extends AutoDisposeAsyncNotifier<List<AssetEntity>> {
+  /// 初期処理
+  @override
+  Future<List<AssetEntity>> build() async {
+    // パーミッション確認
+    if (!await ref.read(permissionServiceProvider).getPhotoPermission()) {
+      throw PermissionException();
+    }
+
+    // 写真取得
+    return ref.read(photoManagerServiceProvider).getAllPhotos();
+  }
+
+  /// 次の写真を取得する
+  /// [isFood] 食べ物かどうか
+  Future<void> loadNext({bool isFood = false}) async {
+    // データがない時は何もしない
+    final value = state.valueOrNull;
+    if (value == null || state.asData == null) {
+      return;
+    }
+
+    // エラーがある時は何もしない
+    if (state.hasError) {
+      return;
+    }
+
+    final photos = state.asData!.value;
+    final length = photos.length;
+    final index = ref.read(photoIndexProvider);
+    final id = photos[index].id;
+
+    try {
+      // 写真登録
+      await ref.read(localPhotoRepositoryProvider).savePhoto(
+            photo: photos[index],
+            isFood: isFood,
+          );
+    } on Exception catch (e, stacktrace) {
+      state = AsyncValue.error(e, stacktrace);
+      return;
+    }
+
+    // 写真のindex更新
+    ref.read(photoIndexProvider.notifier).increment();
+
+    // 最後の写真までスワイプしていない場合
+    if (index != length - 1) {
+      return;
+    }
+
+    // 最後の写真までスワイプした場合
+    // ローディング
+    state = const AsyncValue<List<AssetEntity>>.loading();
+
+    try {
+      // 次の写真リストをDBから取得
+      final results =
+          await ref.read(photoManagerServiceProvider).getAllPhotos(lastId: id);
+
+      // indexクリア
+      ref.read(photoIndexProvider.notifier).clear();
+
+      // 状態更新
+      state = AsyncValue<List<AssetEntity>>.data([
+        ...results,
+      ]);
+    } on Exception catch (e, stacktrace) {
+      state = AsyncValue.error(e, stacktrace);
+      return;
+    }
+  }
+
+  ///　強制リフレッシュ
+  void forceRefresh() {
+    state = const AsyncLoading<List<AssetEntity>>();
+    ref.invalidateSelf();
+  }
+}
+
+final photoListProvider =
+    AsyncNotifierProvider.autoDispose<_PhotoListNotifier, List<AssetEntity>>(
+  _PhotoListNotifier.new,
+);

--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -259,7 +259,7 @@ class _HomePageState extends ConsumerState<HomePage> {
                   );
             } on Exception catch (e) {
               // 例外が発生した場合、エラーメッセージを表示
-              if (context.mounted) {
+              if (context.mounted && mounted) {
                 ScaffoldMessenger.of(context).showSnackBar(
                   SnackBar(content: Text(e.toString())),
                 );

--- a/lib/view/root_page.dart
+++ b/lib/view/root_page.dart
@@ -11,6 +11,7 @@ import '../core/shared_preferences_service.dart';
 import 'home_page.dart';
 import 'my_page.dart';
 import 'onboarding_page.dart';
+import 'swipe_photo_page.dart';
 import 'widgets/confirm_dialog.dart';
 
 /// 全てのページの基盤となるページ
@@ -132,6 +133,15 @@ class _NavigationFrame extends StatelessWidget {
             icon: Padding(
               padding: EdgeInsets.only(top: 10),
               child: Icon(
+                Icons.photo_library,
+              ),
+            ),
+            label: '写真保存',
+          ),
+          BottomNavigationBarItem(
+            icon: Padding(
+              padding: EdgeInsets.only(top: 10),
+              child: Icon(
                 Icons.person,
               ),
             ),
@@ -146,7 +156,8 @@ class _NavigationFrame extends StatelessWidget {
     final location = GoRouterState.of(context).uri.toString();
     return switch (location) {
       HomePage.routePath => 0,
-      MyPage.routePath => 1,
+      SwipePhotoPage.routePath => 1,
+      MyPage.routePath => 2,
       String() => throw UnimplementedError(),
     };
   }
@@ -156,6 +167,8 @@ class _NavigationFrame extends StatelessWidget {
       case 0:
         context.go(HomePage.routePath);
       case 1:
+        context.go(SwipePhotoPage.routePath);
+      case 2:
         context.go(MyPage.routePath);
     }
   }

--- a/lib/view/swipe_photo_page.dart
+++ b/lib/view/swipe_photo_page.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../core/permission_service.dart';
+import '../features/swipe_photo/swipe_photo_controller.dart';
+
+/// 写真スワイプページ
+class SwipePhotoPage extends ConsumerStatefulWidget {
+  const SwipePhotoPage({super.key});
+
+  static const routeName = 'swipe_photo_page';
+  static const routePath = '/swipe_photo_page';
+
+  @override
+  ConsumerState<ConsumerStatefulWidget> createState() => SwipePhotoPageState();
+}
+
+class SwipePhotoPageState extends ConsumerState<SwipePhotoPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(),
+      body: Center(
+        child: ref.watch(photoListProvider).when(
+              data: (photos) {
+                if (photos.isEmpty) {
+                  return const Text('写真がありません。');
+                }
+
+                return Column(
+                  children: [
+                    Expanded(
+                      child: Consumer(
+                        builder: (context, ref, _) {
+                          final index = ref.watch(photoIndexProvider);
+
+                          return FutureBuilder(
+                            future: photos[index].thumbnailData,
+                            builder: (context, snapshot) {
+                              return snapshot.data != null
+                                  ? Card(
+                                      margin: const EdgeInsets.all(16),
+                                      shape: RoundedRectangleBorder(
+                                        borderRadius: BorderRadius.circular(32),
+                                      ),
+                                      clipBehavior: Clip.antiAliasWithSaveLayer,
+                                      child: Image.memory(
+                                        snapshot.data!,
+                                        fit: BoxFit.cover,
+                                      ),
+                                    )
+                                  : const CircularProgressIndicator();
+                            },
+                          );
+                        },
+                      ),
+                    ),
+                    SizedBox(
+                      height: 100,
+                      child: Row(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          SizedBox(
+                            width: 150,
+                            child: ElevatedButton(
+                              onPressed: () {
+                                ref.read(photoListProvider.notifier).loadNext();
+                              },
+                              child: const Text('無視'),
+                            ),
+                          ),
+                          const SizedBox(
+                            width: 16,
+                          ),
+                          SizedBox(
+                            width: 150,
+                            child: ElevatedButton(
+                              onPressed: () {
+                                ref.read(photoListProvider.notifier).loadNext(
+                                      isFood: true,
+                                    );
+                              },
+                              child: const Text('飯'),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                );
+              },
+              error: (error, stackTrace) {
+                if (error is PermissionException) {
+                  return const Text('権限がありません。');
+                }
+                return Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    IconButton(
+                      onPressed: () =>
+                          ref.read(photoListProvider.notifier).forceRefresh(),
+                      icon: const Icon(Icons.refresh),
+                    ),
+                    const Text('エラーが発生しました'),
+                  ],
+                );
+              },
+              loading: () => const CircularProgressIndicator(),
+            ),
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -153,6 +153,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.0"
+  charcode:
+    dependency: transitive
+    description:
+      name: charcode
+      sha256: fb98c0f6d12c920a02ee2d998da788bca066ca5f148492b7085ee23372b12306
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -245,10 +253,10 @@ packages:
     dependency: "direct main"
     description:
       name: collection
-      sha256: f092b211a4319e98e5ff58223576de6c2803db36221657b46c82574721240687
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.2"
+    version: "1.18.0"
   convert:
     dependency: transitive
     description:
@@ -313,6 +321,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.3"
+  device_info_plus:
+    dependency: "direct main"
+    description:
+      name: device_info_plus
+      sha256: eead12d1a1ed83d8283ab4c2f3fca23ac4082f29f25f29dff0f758f57d06ec91
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.1.0"
+  device_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: device_info_plus_platform_interface
+      sha256: d3b01d5868b50ae571cd1dc6e502fc94d956b665756180f7b16ead09e836fd64
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
+  drift:
+    dependency: "direct main"
+    description:
+      name: drift
+      sha256: "049057eba8692cc097c9d0be7612d0a6dd65e3bd283de7e352f9dc81de23169a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.17.0"
+  drift_dev:
+    dependency: "direct dev"
+    description:
+      name: drift_dev
+      sha256: eb327c76604f3e84fff12b246d52da1c160d3aa44d7d433f000d416b4d5e8d8d
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.17.0"
   fake_async:
     dependency: transitive
     description:
@@ -736,6 +776,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.7.1"
+  leak_tracker:
+    dependency: transitive
+    description:
+      name: leak_tracker
+      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.0.0"
+  leak_tracker_flutter_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_flutter_testing
+      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
+  leak_tracker_testing:
+    dependency: transitive
+    description:
+      name: leak_tracker_testing
+      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -764,26 +828,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
+      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16"
+    version: "0.12.16+1"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
+      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.0"
+    version: "0.8.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "3c74dbf8763d36539f114c799d8a2d87343b5067e9d796ca22b5eb8437090ee3"
+      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.1"
+    version: "1.11.0"
   mime:
     dependency: transitive
     description:
@@ -809,13 +873,37 @@ packages:
     source: hosted
     version: "2.0.2"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
-      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
       url: "https://pub.dev"
     source: hosted
-    version: "1.8.3"
+    version: "1.9.0"
+  path_provider:
+    dependency: "direct main"
+    description:
+      name: path_provider
+      sha256: c9e7d3a4cd1410877472158bee69963a4579f78b68c65a2b7d40d1a7a88bb161
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.3"
+  path_provider_android:
+    dependency: transitive
+    description:
+      name: path_provider_android
+      sha256: a248d8146ee5983446bf03ed5ea8f6533129a12b11f12057ad1b4a67a2b3b41d
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.4"
+  path_provider_foundation:
+    dependency: transitive
+    description:
+      name: path_provider_foundation
+      sha256: "5a7999be66e000916500be4f15a3633ebceb8302719b47b9cc49ce924125350f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
   path_provider_linux:
     dependency: transitive
     description:
@@ -848,6 +936,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.24.0+1"
+  permission_handler:
+    dependency: "direct main"
+    description:
+      name: permission_handler
+      sha256: "18bf33f7fefbd812f37e72091a15575e72d5318854877e0e4035a24ac1113ecb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.3.1"
+  permission_handler_android:
+    dependency: transitive
+    description:
+      name: permission_handler_android
+      sha256: "1acac6bae58144b442f11e66621c062aead9c99841093c38f5bcdcc24c1c3474"
+      url: "https://pub.dev"
+    source: hosted
+    version: "12.0.5"
+  permission_handler_apple:
+    dependency: transitive
+    description:
+      name: permission_handler_apple
+      sha256: e9ad66020b89ff1b63908f247c2c6f931c6e62699b756ef8b3c4569350cd8662
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.4.4"
+  permission_handler_html:
+    dependency: transitive
+    description:
+      name: permission_handler_html
+      sha256: "54bf176b90f6eddd4ece307e2c06cf977fb3973719c35a93b85cc7093eb6070d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.1"
+  permission_handler_platform_interface:
+    dependency: transitive
+    description:
+      name: permission_handler_platform_interface
+      sha256: "48d4fcf201a1dad93ee869ab0d4101d084f49136ec82a8a06ed9cfeacab9fd20"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.1"
+  permission_handler_windows:
+    dependency: transitive
+    description:
+      name: permission_handler_windows
+      sha256: "1a790728016f79a41216d88672dbc5df30e686e811ad4e698bfc51f76ad91f1e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.1"
   petitparser:
     dependency: transitive
     description:
@@ -856,6 +992,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.4.0"
+  photo_manager:
+    dependency: "direct main"
+    description:
+      name: photo_manager
+      sha256: df594f989f0c31cdb3ed48f3d49cb9ffadf11cc3700d2c3460b1912c93432621
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.0"
   platform:
     dependency: transitive
     description:
@@ -912,6 +1056,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
+  recase:
+    dependency: transitive
+    description:
+      name: recase
+      sha256: e4eb4ec2dcdee52dcf99cb4ceabaffc631d7424ee55e56f280bc039737f89213
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
   riverpod:
     dependency: transitive
     description:
@@ -1053,14 +1205,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.0"
+  sqlite3:
+    dependency: transitive
+    description:
+      name: sqlite3
+      sha256: "1abbeb84bf2b1a10e5e1138c913123c8aa9d83cd64e5f9a0dd847b3c83063202"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.4.2"
+  sqlite3_flutter_libs:
+    dependency: "direct main"
+    description:
+      name: sqlite3_flutter_libs
+      sha256: fb2a106a2ea6042fe57de2c47074cc31539a941819c91e105b864744605da3f5
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.21"
+  sqlparser:
+    dependency: transitive
+    description:
+      name: sqlparser
+      sha256: ce244c25100319b3fe1a7774c091f89faf3101adb73d75f1297e56d247f66b2b
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.35.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
   state_notifier:
     dependency: transitive
     description:
@@ -1073,10 +1249,10 @@ packages:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   stream_transform:
     dependency: transitive
     description:
@@ -1105,10 +1281,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "75760ffd7786fffdfb9597c35c5b27eaeec82be8edfb6d71d32651128ed7aab8"
+      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.0"
+    version: "0.6.1"
   timing:
     dependency: transitive
     description:
@@ -1233,10 +1409,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: dc8ccd225a2005c1be616fe02951e2e342092edf968cf0844220383757ef8f10
+      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
       url: "https://pub.dev"
     source: hosted
-    version: "0.1.4-beta"
+    version: "0.5.1"
   web_socket_channel:
     dependency: transitive
     description:
@@ -1253,6 +1429,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
+  win32_registry:
+    dependency: transitive
+    description:
+      name: win32_registry
+      sha256: "41fd8a189940d8696b1b810efb9abcf60827b6cbfab90b0c43e8439e3a39d85a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
   xdg_directories:
     dependency: transitive
     description:
@@ -1278,5 +1462,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.1.0 <4.0.0"
-  flutter: ">=3.13.0"
+  dart: ">=3.3.0 <4.0.0"
+  flutter: ">=3.16.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -325,10 +325,10 @@ packages:
     dependency: "direct main"
     description:
       name: device_info_plus
-      sha256: eead12d1a1ed83d8283ab4c2f3fca23ac4082f29f25f29dff0f758f57d06ec91
+      sha256: "77f757b789ff68e4eaf9c56d1752309bd9f7ad557cb105b938a7f8eb89e59110"
       url: "https://pub.dev"
     source: hosted
-    version: "10.1.0"
+    version: "9.1.2"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -341,18 +341,18 @@ packages:
     dependency: "direct main"
     description:
       name: drift
-      sha256: "049057eba8692cc097c9d0be7612d0a6dd65e3bd283de7e352f9dc81de23169a"
+      sha256: b50a8342c6ddf05be53bda1d246404cbad101b64dc73e8d6d1ac1090d119b4e2
       url: "https://pub.dev"
     source: hosted
-    version: "2.17.0"
+    version: "2.15.0"
   drift_dev:
     dependency: "direct dev"
     description:
       name: drift_dev
-      sha256: eb327c76604f3e84fff12b246d52da1c160d3aa44d7d433f000d416b4d5e8d8d
+      sha256: c037d9431b6f8dc633652b1469e5f53aaec6e4eb405ed29dd232fa888ef10d88
       url: "https://pub.dev"
     source: hosted
-    version: "2.17.0"
+    version: "2.15.0"
   fake_async:
     dependency: transitive
     description:
@@ -776,30 +776,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.7.1"
-  leak_tracker:
-    dependency: transitive
-    description:
-      name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
-      url: "https://pub.dev"
-    source: hosted
-    version: "10.0.0"
-  leak_tracker_flutter_testing:
-    dependency: transitive
-    description:
-      name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
-  leak_tracker_testing:
-    dependency: transitive
-    description:
-      name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.1"
   lints:
     dependency: transitive
     description:
@@ -828,26 +804,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: "1803e76e6653768d64ed8ff2e1e67bea3ad4b923eb5c56a295c3e634bad5960e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.16"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: "9528f2f296073ff54cb9fee677df673ace1218163c3bc7628093e7eed5203d41"
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.5.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: a6e590c838b18133bb482a2745ad77c5bb7715fb0451209e1a7567d416678b8e
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.10.0"
   mime:
     dependency: transitive
     description:
@@ -876,10 +852,10 @@ packages:
     dependency: "direct main"
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.8.3"
   path_provider:
     dependency: "direct main"
     description:
@@ -1209,10 +1185,10 @@ packages:
     dependency: transitive
     description:
       name: sqlite3
-      sha256: "1abbeb84bf2b1a10e5e1138c913123c8aa9d83cd64e5f9a0dd847b3c83063202"
+      sha256: "072128763f1547e3e9b4735ce846bfd226d68019ccda54db4cd427b12dfdedc9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.4.0"
   sqlite3_flutter_libs:
     dependency: "direct main"
     description:
@@ -1225,10 +1201,10 @@ packages:
     dependency: transitive
     description:
       name: sqlparser
-      sha256: ce244c25100319b3fe1a7774c091f89faf3101adb73d75f1297e56d247f66b2b
+      sha256: "7b20045d1ccfb7bc1df7e8f9fee5ae58673fce6ff62cefbb0e0fd7214e90e5a0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.35.1"
+    version: "0.34.1"
   stack_trace:
     dependency: transitive
     description:
@@ -1409,10 +1385,10 @@ packages:
     dependency: transitive
     description:
       name: web
-      sha256: "97da13628db363c635202ad97068d47c5b8aa555808e7a9411963c533b449b27"
+      sha256: afe077240a270dcfd2aafe77602b4113645af95d0ad31128cc02bce5ac5d5152
       url: "https://pub.dev"
     source: hosted
-    version: "0.5.1"
+    version: "0.3.0"
   web_socket_channel:
     dependency: transitive
     description:
@@ -1462,5 +1438,5 @@ packages:
     source: hosted
     version: "3.1.2"
 sdks:
-  dart: ">=3.3.0 <4.0.0"
+  dart: ">=3.2.0 <4.0.0"
   flutter: ">=3.16.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,8 +13,8 @@ dependencies:
   cloud_functions: any
   collection: ^1.17.2
   cupertino_icons: ^1.0.2
-  device_info_plus: ^10.1.0
-  drift: ^2.17.0
+  device_info_plus: ^9.1.2
+  drift: ^2.15.0
   firebase_analytics: any
   firebase_auth: any
   firebase_core: any
@@ -34,7 +34,7 @@ dependencies:
   http: ^0.13.3
   logger: null
   package_info: ^2.0.2
-  path: ^1.9.0
+  path: ^1.8.3
   path_provider: ^2.1.3
   permission_handler: ^11.3.1
   photo_manager: ^3.0.0
@@ -49,7 +49,7 @@ dev_dependencies:
   build_runner: ^2.4.6
   change_app_package_name:
   custom_lint: ^0.5.4
-  drift_dev: ^2.17.0
+  drift_dev: ^2.15.0
   flutter_native_splash: ^2.3.7
   flutter_test:
     sdk: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,8 @@ dependencies:
   cloud_functions: any
   collection: ^1.17.2
   cupertino_icons: ^1.0.2
+  device_info_plus: ^10.1.0
+  drift: ^2.17.0
   firebase_analytics: any
   firebase_auth: any
   firebase_core: any
@@ -32,8 +34,14 @@ dependencies:
   http: ^0.13.3
   logger: null
   package_info: ^2.0.2
+  path: ^1.9.0
+  path_provider: ^2.1.3
+  permission_handler: ^11.3.1
+  photo_manager: ^3.0.0
   shared_preferences: ^2.2.2
+  sqlite3_flutter_libs: ^0.5.21
   url_launcher: ^6.2.4
+
 # ビルドで失敗したため、一旦除外。セキュリティリスクのため後で対応。
 # recaptcha_enterprise_flutter: ^18.4.0
 
@@ -41,6 +49,7 @@ dev_dependencies:
   build_runner: ^2.4.6
   change_app_package_name:
   custom_lint: ^0.5.4
+  drift_dev: ^2.17.0
   flutter_native_splash: ^2.3.7
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
## 関連のタスク issue
<!-- Notionリンクを記載  -->
後でリンク記載

## 対応したこと
<!-- 実装の概要を箇条書きする  -->
- とりあえず写真スワイプ用のページを作成しました。
- photo_managerを使用してローカルから写真情報の取得処理を作成しました。
- ボタンをタップした時に写真情報をDB(Drift)に保存する処理を作成しました。
- アプリを再起動した場合、前回の途中から写真情報を取得するようにしました。

## 未解決事項
<!-- 別PRで対応するような状況があれば記載  -->  
- Tinder風のUI作成は未対応です。
- iOSで動作確認できてません。
- 画像取得の権限で拒否された場合のUI
  - 現状は権限がありませんとだけ表示してます。
- 画像スワイプ完了した場合のUI
  - 現状は写真がありませんとだけ表示してます。
- 保存処理でエラーが発生した場合のUI 
  - 現状はエラーが発生しましたの文言とボタン押下で再度取得するようにしてます。
- 保存した写真のパスを元に画像を表示する際に、オリジナル画像が削除されている可能性があるので、表示する際はその考慮が必要だと思います。

## 実際の挙動
<!-- UIに関わるようであればスクリーンショット、動きのあるものは動画 or GIF  -->  
<!-- 入力エリアにドラッグ&ドロップしてアップロード  -->
![record](https://github.com/schwarzwald0906/My_Gourmet/assets/103257145/97e67a6e-2dc6-4b09-ba46-8265c212836f)

## DB構成
<img width="1512" alt="スクリーンショット 2024-04-28 12 53 29" src="https://github.com/schwarzwald0906/My_Gourmet/assets/103257145/9be664ce-2cbf-4fa3-bb0a-94a243b3e5d2">

## チェックリスト
<!-- 空白を消して`x`をつける  -->  
- ✖︎ 実装完了後、問題が起こっていないか実際に動作確認したか
- ✖︎ 補足があった方が良い/重点的にレビューが欲しい箇所にGitHub上でコメントをしたか

## その他コメント
<!-- 何かあれば！  -->










