### PR TITLE
写真保存機能修正

### DIFF
--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -9,24 +9,31 @@ part 'database.g.dart';
 
 /// 写真テーブル
 @DataClassName('Photo')
-@TableIndex(name: 'photo_id', columns: {#id})
-@TableIndex(name: 'photo_is_food', columns: {#isFood})
 class Photos extends Table {
-  // IntColumn get id => integer().autoIncrement()();
-
   /// 写真のid
-  TextColumn get id => text().unique()();
+  TextColumn get id => text()();
 
   /// 写真のパス
   TextColumn get path => text()();
 
-// DateTimeColumn get date => dateTime()();
-  /// 食べ物かどうか
-  BoolColumn get isFood => boolean()();
+  /// 主キー設定
+  @override
+  Set<Column> get primaryKey => {id};
+}
+
+/// 最後に処理した写真情報を保存するテーブル
+@DataClassName('LastPhoto')
+class LastPhotos extends Table {
+  /// 写真のid
+  TextColumn get id => text()();
+
+  /// 主キー設定
+  @override
+  Set<Column> get primaryKey => {id};
 }
 
 /// DB設定
-@DriftDatabase(tables: [Photos])
+@DriftDatabase(tables: [Photos, LastPhotos])
 class AppDatabase extends _$AppDatabase {
   // 引数なしのコンストラクタで_openConnectionを直接使用
   AppDatabase() : super(_openConnection());

--- a/lib/core/database/database.g.dart
+++ b/lib/core/database/database.g.dart
@@ -12,24 +12,14 @@ class $PhotosTable extends Photos with TableInfo<$PhotosTable, Photo> {
   @override
   late final GeneratedColumn<String> id = GeneratedColumn<String>(
       'id', aliasedName, false,
-      type: DriftSqlType.string,
-      requiredDuringInsert: true,
-      defaultConstraints: GeneratedColumn.constraintIsAlways('UNIQUE'));
+      type: DriftSqlType.string, requiredDuringInsert: true);
   static const VerificationMeta _pathMeta = const VerificationMeta('path');
   @override
   late final GeneratedColumn<String> path = GeneratedColumn<String>(
       'path', aliasedName, false,
       type: DriftSqlType.string, requiredDuringInsert: true);
-  static const VerificationMeta _isFoodMeta = const VerificationMeta('isFood');
   @override
-  late final GeneratedColumn<bool> isFood = GeneratedColumn<bool>(
-      'is_food', aliasedName, false,
-      type: DriftSqlType.bool,
-      requiredDuringInsert: true,
-      defaultConstraints:
-          GeneratedColumn.constraintIsAlways('CHECK ("is_food" IN (0, 1))'));
-  @override
-  List<GeneratedColumn> get $columns => [id, path, isFood];
+  List<GeneratedColumn> get $columns => [id, path];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
@@ -51,17 +41,11 @@ class $PhotosTable extends Photos with TableInfo<$PhotosTable, Photo> {
     } else if (isInserting) {
       context.missing(_pathMeta);
     }
-    if (data.containsKey('is_food')) {
-      context.handle(_isFoodMeta,
-          isFood.isAcceptableOrUnknown(data['is_food']!, _isFoodMeta));
-    } else if (isInserting) {
-      context.missing(_isFoodMeta);
-    }
     return context;
   }
 
   @override
-  Set<GeneratedColumn> get $primaryKey => const {};
+  Set<GeneratedColumn> get $primaryKey => {id};
   @override
   Photo map(Map<String, dynamic> data, {String? tablePrefix}) {
     final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
@@ -70,8 +54,6 @@ class $PhotosTable extends Photos with TableInfo<$PhotosTable, Photo> {
           .read(DriftSqlType.string, data['${effectivePrefix}id'])!,
       path: attachedDatabase.typeMapping
           .read(DriftSqlType.string, data['${effectivePrefix}path'])!,
-      isFood: attachedDatabase.typeMapping
-          .read(DriftSqlType.bool, data['${effectivePrefix}is_food'])!,
     );
   }
 
@@ -87,16 +69,12 @@ class Photo extends DataClass implements Insertable<Photo> {
 
   /// 写真のパス
   final String path;
-
-  /// 食べ物かどうか
-  final bool isFood;
-  const Photo({required this.id, required this.path, required this.isFood});
+  const Photo({required this.id, required this.path});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
     map['id'] = Variable<String>(id);
     map['path'] = Variable<String>(path);
-    map['is_food'] = Variable<bool>(isFood);
     return map;
   }
 
@@ -104,7 +82,6 @@ class Photo extends DataClass implements Insertable<Photo> {
     return PhotosCompanion(
       id: Value(id),
       path: Value(path),
-      isFood: Value(isFood),
     );
   }
 
@@ -114,7 +91,6 @@ class Photo extends DataClass implements Insertable<Photo> {
     return Photo(
       id: serializer.fromJson<String>(json['id']),
       path: serializer.fromJson<String>(json['path']),
-      isFood: serializer.fromJson<bool>(json['isFood']),
     );
   }
   @override
@@ -123,78 +99,62 @@ class Photo extends DataClass implements Insertable<Photo> {
     return <String, dynamic>{
       'id': serializer.toJson<String>(id),
       'path': serializer.toJson<String>(path),
-      'isFood': serializer.toJson<bool>(isFood),
     };
   }
 
-  Photo copyWith({String? id, String? path, bool? isFood}) => Photo(
+  Photo copyWith({String? id, String? path}) => Photo(
         id: id ?? this.id,
         path: path ?? this.path,
-        isFood: isFood ?? this.isFood,
       );
   @override
   String toString() {
     return (StringBuffer('Photo(')
           ..write('id: $id, ')
-          ..write('path: $path, ')
-          ..write('isFood: $isFood')
+          ..write('path: $path')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode => Object.hash(id, path, isFood);
+  int get hashCode => Object.hash(id, path);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      (other is Photo &&
-          other.id == this.id &&
-          other.path == this.path &&
-          other.isFood == this.isFood);
+      (other is Photo && other.id == this.id && other.path == this.path);
 }
 
 class PhotosCompanion extends UpdateCompanion<Photo> {
   final Value<String> id;
   final Value<String> path;
-  final Value<bool> isFood;
   final Value<int> rowid;
   const PhotosCompanion({
     this.id = const Value.absent(),
     this.path = const Value.absent(),
-    this.isFood = const Value.absent(),
     this.rowid = const Value.absent(),
   });
   PhotosCompanion.insert({
     required String id,
     required String path,
-    required bool isFood,
     this.rowid = const Value.absent(),
   })  : id = Value(id),
-        path = Value(path),
-        isFood = Value(isFood);
+        path = Value(path);
   static Insertable<Photo> custom({
     Expression<String>? id,
     Expression<String>? path,
-    Expression<bool>? isFood,
     Expression<int>? rowid,
   }) {
     return RawValuesInsertable({
       if (id != null) 'id': id,
       if (path != null) 'path': path,
-      if (isFood != null) 'is_food': isFood,
       if (rowid != null) 'rowid': rowid,
     });
   }
 
   PhotosCompanion copyWith(
-      {Value<String>? id,
-      Value<String>? path,
-      Value<bool>? isFood,
-      Value<int>? rowid}) {
+      {Value<String>? id, Value<String>? path, Value<int>? rowid}) {
     return PhotosCompanion(
       id: id ?? this.id,
       path: path ?? this.path,
-      isFood: isFood ?? this.isFood,
       rowid: rowid ?? this.rowid,
     );
   }
@@ -208,9 +168,6 @@ class PhotosCompanion extends UpdateCompanion<Photo> {
     if (path.present) {
       map['path'] = Variable<String>(path.value);
     }
-    if (isFood.present) {
-      map['is_food'] = Variable<bool>(isFood.value);
-    }
     if (rowid.present) {
       map['rowid'] = Variable<int>(rowid.value);
     }
@@ -222,7 +179,154 @@ class PhotosCompanion extends UpdateCompanion<Photo> {
     return (StringBuffer('PhotosCompanion(')
           ..write('id: $id, ')
           ..write('path: $path, ')
-          ..write('isFood: $isFood, ')
+          ..write('rowid: $rowid')
+          ..write(')'))
+        .toString();
+  }
+}
+
+class $LastPhotosTable extends LastPhotos
+    with TableInfo<$LastPhotosTable, LastPhoto> {
+  @override
+  final GeneratedDatabase attachedDatabase;
+  final String? _alias;
+  $LastPhotosTable(this.attachedDatabase, [this._alias]);
+  static const VerificationMeta _idMeta = const VerificationMeta('id');
+  @override
+  late final GeneratedColumn<String> id = GeneratedColumn<String>(
+      'id', aliasedName, false,
+      type: DriftSqlType.string, requiredDuringInsert: true);
+  @override
+  List<GeneratedColumn> get $columns => [id];
+  @override
+  String get aliasedName => _alias ?? actualTableName;
+  @override
+  String get actualTableName => $name;
+  static const String $name = 'last_photos';
+  @override
+  VerificationContext validateIntegrity(Insertable<LastPhoto> instance,
+      {bool isInserting = false}) {
+    final context = VerificationContext();
+    final data = instance.toColumns(true);
+    if (data.containsKey('id')) {
+      context.handle(_idMeta, id.isAcceptableOrUnknown(data['id']!, _idMeta));
+    } else if (isInserting) {
+      context.missing(_idMeta);
+    }
+    return context;
+  }
+
+  @override
+  Set<GeneratedColumn> get $primaryKey => {id};
+  @override
+  LastPhoto map(Map<String, dynamic> data, {String? tablePrefix}) {
+    final effectivePrefix = tablePrefix != null ? '$tablePrefix.' : '';
+    return LastPhoto(
+      id: attachedDatabase.typeMapping
+          .read(DriftSqlType.string, data['${effectivePrefix}id'])!,
+    );
+  }
+
+  @override
+  $LastPhotosTable createAlias(String alias) {
+    return $LastPhotosTable(attachedDatabase, alias);
+  }
+}
+
+class LastPhoto extends DataClass implements Insertable<LastPhoto> {
+  /// 写真のid
+  final String id;
+  const LastPhoto({required this.id});
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    map['id'] = Variable<String>(id);
+    return map;
+  }
+
+  LastPhotosCompanion toCompanion(bool nullToAbsent) {
+    return LastPhotosCompanion(
+      id: Value(id),
+    );
+  }
+
+  factory LastPhoto.fromJson(Map<String, dynamic> json,
+      {ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return LastPhoto(
+      id: serializer.fromJson<String>(json['id']),
+    );
+  }
+  @override
+  Map<String, dynamic> toJson({ValueSerializer? serializer}) {
+    serializer ??= driftRuntimeOptions.defaultSerializer;
+    return <String, dynamic>{
+      'id': serializer.toJson<String>(id),
+    };
+  }
+
+  LastPhoto copyWith({String? id}) => LastPhoto(
+        id: id ?? this.id,
+      );
+  @override
+  String toString() {
+    return (StringBuffer('LastPhoto(')
+          ..write('id: $id')
+          ..write(')'))
+        .toString();
+  }
+
+  @override
+  int get hashCode => id.hashCode;
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) || (other is LastPhoto && other.id == this.id);
+}
+
+class LastPhotosCompanion extends UpdateCompanion<LastPhoto> {
+  final Value<String> id;
+  final Value<int> rowid;
+  const LastPhotosCompanion({
+    this.id = const Value.absent(),
+    this.rowid = const Value.absent(),
+  });
+  LastPhotosCompanion.insert({
+    required String id,
+    this.rowid = const Value.absent(),
+  }) : id = Value(id);
+  static Insertable<LastPhoto> custom({
+    Expression<String>? id,
+    Expression<int>? rowid,
+  }) {
+    return RawValuesInsertable({
+      if (id != null) 'id': id,
+      if (rowid != null) 'rowid': rowid,
+    });
+  }
+
+  LastPhotosCompanion copyWith({Value<String>? id, Value<int>? rowid}) {
+    return LastPhotosCompanion(
+      id: id ?? this.id,
+      rowid: rowid ?? this.rowid,
+    );
+  }
+
+  @override
+  Map<String, Expression> toColumns(bool nullToAbsent) {
+    final map = <String, Expression>{};
+    if (id.present) {
+      map['id'] = Variable<String>(id.value);
+    }
+    if (rowid.present) {
+      map['rowid'] = Variable<int>(rowid.value);
+    }
+    return map;
+  }
+
+  @override
+  String toString() {
+    return (StringBuffer('LastPhotosCompanion(')
+          ..write('id: $id, ')
           ..write('rowid: $rowid')
           ..write(')'))
         .toString();
@@ -232,14 +336,10 @@ class PhotosCompanion extends UpdateCompanion<Photo> {
 abstract class _$AppDatabase extends GeneratedDatabase {
   _$AppDatabase(QueryExecutor e) : super(e);
   late final $PhotosTable photos = $PhotosTable(this);
-  late final Index photoId =
-      Index('photo_id', 'CREATE INDEX photo_id ON photos (id)');
-  late final Index photoIsFood =
-      Index('photo_is_food', 'CREATE INDEX photo_is_food ON photos (is_food)');
+  late final $LastPhotosTable lastPhotos = $LastPhotosTable(this);
   @override
   Iterable<TableInfo<Table, Object?>> get allTables =>
       allSchemaEntities.whereType<TableInfo<Table, Object?>>();
   @override
-  List<DatabaseSchemaEntity> get allSchemaEntities =>
-      [photos, photoId, photoIsFood];
+  List<DatabaseSchemaEntity> get allSchemaEntities => [photos, lastPhotos];
 }


### PR DESCRIPTION
## 関連のタスク issue
<!-- Notionリンクを記載  -->
なし

## 対応したこと
<!-- 実装の概要を箇条書きする  -->
- 飯以外の写真データも保存するようになっていたのを修正しました。
- DB構成を変更しました。
  - 写真テーブルの構成変更
  - 最後に処理したidを保存するテーブル追加
     ※アプリを再起動した場合も途中から始められるように

## 未解決事項
<!-- 別PRで対応するような状況があれば記載  -->  
- なし

## 実際の挙動
<!-- UIに関わるようであればスクリーンショット、動きのあるものは動画 or GIF  -->  
<!-- 入力エリアにドラッグ&ドロップしてアップロード  -->
![record](https://github.com/schwarzwald0906/My_Gourmet/assets/103257145/08d964fa-68b9-48a9-b5f4-5b0a5fddeaa9)

## チェックリスト
<!-- 空白を消して`x`をつける  -->  
- [x] 実装完了後、問題が起こっていないか実際に動作確認したか  
- [x] 補足があった方が良い/重点的にレビューが欲しい箇所にGitHub上でコメントをしたか

## その他コメント

<!-- 何かあれば！  -->
DB構成変更しているのでアプリ再インストール必要です。
