### PR TITLE
完了画面で表示される枚数の修正

### DIFF
--- a/lib/core/database/database.dart
+++ b/lib/core/database/database.dart
@@ -32,6 +32,9 @@ class PhotoDetails extends Table {
 
   /// 現在の写真処理数
   IntColumn get currentCount => integer()();
+
+  /// 過去のグルメ分類合計枚数(追加された写真をカウントするのに使用)
+  IntColumn get pastFoodTotal => integer()();
 }
 
 /// DB設定

--- a/lib/core/database/database.g.dart
+++ b/lib/core/database/database.g.dart
@@ -208,9 +208,15 @@ class $PhotoDetailsTable extends PhotoDetails
   late final GeneratedColumn<int> currentCount = GeneratedColumn<int>(
       'current_count', aliasedName, false,
       type: DriftSqlType.int, requiredDuringInsert: true);
+  static const VerificationMeta _pastFoodTotalMeta =
+      const VerificationMeta('pastFoodTotal');
+  @override
+  late final GeneratedColumn<int> pastFoodTotal = GeneratedColumn<int>(
+      'past_food_total', aliasedName, false,
+      type: DriftSqlType.int, requiredDuringInsert: true);
   @override
   List<GeneratedColumn> get $columns =>
-      [lastId, lastCreateDateSecond, currentCount];
+      [lastId, lastCreateDateSecond, currentCount, pastFoodTotal];
   @override
   String get aliasedName => _alias ?? actualTableName;
   @override
@@ -243,6 +249,14 @@ class $PhotoDetailsTable extends PhotoDetails
     } else if (isInserting) {
       context.missing(_currentCountMeta);
     }
+    if (data.containsKey('past_food_total')) {
+      context.handle(
+          _pastFoodTotalMeta,
+          pastFoodTotal.isAcceptableOrUnknown(
+              data['past_food_total']!, _pastFoodTotalMeta));
+    } else if (isInserting) {
+      context.missing(_pastFoodTotalMeta);
+    }
     return context;
   }
 
@@ -258,6 +272,8 @@ class $PhotoDetailsTable extends PhotoDetails
           DriftSqlType.int, data['${effectivePrefix}last_create_date_second'])!,
       currentCount: attachedDatabase.typeMapping
           .read(DriftSqlType.int, data['${effectivePrefix}current_count'])!,
+      pastFoodTotal: attachedDatabase.typeMapping
+          .read(DriftSqlType.int, data['${effectivePrefix}past_food_total'])!,
     );
   }
 
@@ -276,16 +292,21 @@ class PhotoDetail extends DataClass implements Insertable<PhotoDetail> {
 
   /// 現在の写真処理数
   final int currentCount;
+
+  /// 過去のグルメ分類合計枚数(追加された写真をカウントするのに使用)
+  final int pastFoodTotal;
   const PhotoDetail(
       {required this.lastId,
       required this.lastCreateDateSecond,
-      required this.currentCount});
+      required this.currentCount,
+      required this.pastFoodTotal});
   @override
   Map<String, Expression> toColumns(bool nullToAbsent) {
     final map = <String, Expression>{};
     map['last_id'] = Variable<String>(lastId);
     map['last_create_date_second'] = Variable<int>(lastCreateDateSecond);
     map['current_count'] = Variable<int>(currentCount);
+    map['past_food_total'] = Variable<int>(pastFoodTotal);
     return map;
   }
 
@@ -294,6 +315,7 @@ class PhotoDetail extends DataClass implements Insertable<PhotoDetail> {
       lastId: Value(lastId),
       lastCreateDateSecond: Value(lastCreateDateSecond),
       currentCount: Value(currentCount),
+      pastFoodTotal: Value(pastFoodTotal),
     );
   }
 
@@ -305,6 +327,7 @@ class PhotoDetail extends DataClass implements Insertable<PhotoDetail> {
       lastCreateDateSecond:
           serializer.fromJson<int>(json['lastCreateDateSecond']),
       currentCount: serializer.fromJson<int>(json['currentCount']),
+      pastFoodTotal: serializer.fromJson<int>(json['pastFoodTotal']),
     );
   }
   @override
@@ -314,60 +337,73 @@ class PhotoDetail extends DataClass implements Insertable<PhotoDetail> {
       'lastId': serializer.toJson<String>(lastId),
       'lastCreateDateSecond': serializer.toJson<int>(lastCreateDateSecond),
       'currentCount': serializer.toJson<int>(currentCount),
+      'pastFoodTotal': serializer.toJson<int>(pastFoodTotal),
     };
   }
 
   PhotoDetail copyWith(
-          {String? lastId, int? lastCreateDateSecond, int? currentCount}) =>
+          {String? lastId,
+          int? lastCreateDateSecond,
+          int? currentCount,
+          int? pastFoodTotal}) =>
       PhotoDetail(
         lastId: lastId ?? this.lastId,
         lastCreateDateSecond: lastCreateDateSecond ?? this.lastCreateDateSecond,
         currentCount: currentCount ?? this.currentCount,
+        pastFoodTotal: pastFoodTotal ?? this.pastFoodTotal,
       );
   @override
   String toString() {
     return (StringBuffer('PhotoDetail(')
           ..write('lastId: $lastId, ')
           ..write('lastCreateDateSecond: $lastCreateDateSecond, ')
-          ..write('currentCount: $currentCount')
+          ..write('currentCount: $currentCount, ')
+          ..write('pastFoodTotal: $pastFoodTotal')
           ..write(')'))
         .toString();
   }
 
   @override
-  int get hashCode => Object.hash(lastId, lastCreateDateSecond, currentCount);
+  int get hashCode =>
+      Object.hash(lastId, lastCreateDateSecond, currentCount, pastFoodTotal);
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       (other is PhotoDetail &&
           other.lastId == this.lastId &&
           other.lastCreateDateSecond == this.lastCreateDateSecond &&
-          other.currentCount == this.currentCount);
+          other.currentCount == this.currentCount &&
+          other.pastFoodTotal == this.pastFoodTotal);
 }
 
 class PhotoDetailsCompanion extends UpdateCompanion<PhotoDetail> {
   final Value<String> lastId;
   final Value<int> lastCreateDateSecond;
   final Value<int> currentCount;
+  final Value<int> pastFoodTotal;
   final Value<int> rowid;
   const PhotoDetailsCompanion({
     this.lastId = const Value.absent(),
     this.lastCreateDateSecond = const Value.absent(),
     this.currentCount = const Value.absent(),
+    this.pastFoodTotal = const Value.absent(),
     this.rowid = const Value.absent(),
   });
   PhotoDetailsCompanion.insert({
     required String lastId,
     required int lastCreateDateSecond,
     required int currentCount,
+    required int pastFoodTotal,
     this.rowid = const Value.absent(),
   })  : lastId = Value(lastId),
         lastCreateDateSecond = Value(lastCreateDateSecond),
-        currentCount = Value(currentCount);
+        currentCount = Value(currentCount),
+        pastFoodTotal = Value(pastFoodTotal);
   static Insertable<PhotoDetail> custom({
     Expression<String>? lastId,
     Expression<int>? lastCreateDateSecond,
     Expression<int>? currentCount,
+    Expression<int>? pastFoodTotal,
     Expression<int>? rowid,
   }) {
     return RawValuesInsertable({
@@ -375,6 +411,7 @@ class PhotoDetailsCompanion extends UpdateCompanion<PhotoDetail> {
       if (lastCreateDateSecond != null)
         'last_create_date_second': lastCreateDateSecond,
       if (currentCount != null) 'current_count': currentCount,
+      if (pastFoodTotal != null) 'past_food_total': pastFoodTotal,
       if (rowid != null) 'rowid': rowid,
     });
   }
@@ -383,11 +420,13 @@ class PhotoDetailsCompanion extends UpdateCompanion<PhotoDetail> {
       {Value<String>? lastId,
       Value<int>? lastCreateDateSecond,
       Value<int>? currentCount,
+      Value<int>? pastFoodTotal,
       Value<int>? rowid}) {
     return PhotoDetailsCompanion(
       lastId: lastId ?? this.lastId,
       lastCreateDateSecond: lastCreateDateSecond ?? this.lastCreateDateSecond,
       currentCount: currentCount ?? this.currentCount,
+      pastFoodTotal: pastFoodTotal ?? this.pastFoodTotal,
       rowid: rowid ?? this.rowid,
     );
   }
@@ -405,6 +444,9 @@ class PhotoDetailsCompanion extends UpdateCompanion<PhotoDetail> {
     if (currentCount.present) {
       map['current_count'] = Variable<int>(currentCount.value);
     }
+    if (pastFoodTotal.present) {
+      map['past_food_total'] = Variable<int>(pastFoodTotal.value);
+    }
     if (rowid.present) {
       map['rowid'] = Variable<int>(rowid.value);
     }
@@ -417,6 +459,7 @@ class PhotoDetailsCompanion extends UpdateCompanion<PhotoDetail> {
           ..write('lastId: $lastId, ')
           ..write('lastCreateDateSecond: $lastCreateDateSecond, ')
           ..write('currentCount: $currentCount, ')
+          ..write('pastFoodTotal: $pastFoodTotal, ')
           ..write('rowid: $rowid')
           ..write(')'))
         .toString();

--- a/lib/core/local_photo_repository.dart
+++ b/lib/core/local_photo_repository.dart
@@ -31,7 +31,7 @@ class LocalPhotoRepository {
   }
 
   /// グルメ分類合計枚数を取得する
-  Future<int> getFoodTotal() async {
+  Future<int> getFoodPhotoTotal() async {
     // 過去のグルメ分類合計枚数取得
     final photoDetail = await getPhotoDetail();
 

--- a/lib/core/photo_manager_service.dart
+++ b/lib/core/photo_manager_service.dart
@@ -17,6 +17,9 @@ class PhotoService {
 
   final Ref ref;
 
+  LocalPhotoRepository get _localPhotoRepository =>
+      ref.read(localPhotoRepositoryProvider);
+
   /// 写真取得
   /// [lastEntity] 最後の写真情報
   Future<List<AssetEntity>> getAllPhotos({AssetEntity? lastEntity}) async {
@@ -25,8 +28,7 @@ class PhotoService {
     // 初回ロード
     if (lastEntity == null) {
       // DBから写真情報を取得
-      final photoDetail =
-      await ref.read(localPhotoRepositoryProvider).getPhotoDetail();
+      final photoDetail = await _localPhotoRepository.getPhotoDetail();
 
       // PhotoManagerから写真数取得
       final totalCount = await PhotoManager.getAssetCount(
@@ -82,9 +84,9 @@ class PhotoService {
   /// [lastId] 最後の写真id
   /// [lastDate] 最後の写真日付
   AdvancedCustomFilter _getPhotoFilter(
-      String lastId,
-      DateTime lastDate,
-      ) {
+    String lastId,
+    DateTime lastDate,
+  ) {
     if (Platform.isAndroid) {
       return _getPhotoFilterForAndroid(lastId);
     } else {
@@ -96,8 +98,8 @@ class PhotoService {
   /// 写真idでフィルタリングする
   /// [lastId] 最後の写真id
   AdvancedCustomFilter _getPhotoFilterForAndroid(
-      String lastId,
-      ) {
+    String lastId,
+  ) {
     return AdvancedCustomFilter(
       where: [
         ColumnWhereCondition(
@@ -113,8 +115,8 @@ class PhotoService {
   /// 写真日付でフィルタリングする
   /// [lastDate] 最後の写真日付
   AdvancedCustomFilter _getPhotoFilterForIos(
-      DateTime lastDate,
-      ) {
+    DateTime lastDate,
+  ) {
     return AdvancedCustomFilter(
       where: [
         DateColumnWhereCondition(

--- a/lib/features/swipe_photo/swipe_photo_controller.dart
+++ b/lib/features/swipe_photo/swipe_photo_controller.dart
@@ -40,17 +40,17 @@ final photoCountProvider =
 
 /// グルメの登録数を取得するProvider
 /// 分類完了後の 「追加された写真 ＋XXX枚」に使用
-class _FoodPhotoCountNotifier extends AutoDisposeAsyncNotifier<int> {
+class _FoodPhotoTotalNotifier extends AutoDisposeAsyncNotifier<int> {
   @override
   Future<int> build() async {
     // 取得できない場合はデフォルト値設定
-    return ref.read(localPhotoRepositoryProvider).getFoodTotal();
+    return ref.read(localPhotoRepositoryProvider).getFoodPhotoTotal();
   }
 }
 
-final foodPhotoCountProvider =
-    AsyncNotifierProvider.autoDispose<_FoodPhotoCountNotifier, int>(
-  _FoodPhotoCountNotifier.new,
+final foodPhotoTotalProvider =
+    AsyncNotifierProvider.autoDispose<_FoodPhotoTotalNotifier, int>(
+  _FoodPhotoTotalNotifier.new,
 );
 
 /// 写真を取得するProvider

--- a/lib/features/swipe_photo/swipe_photo_controller.dart
+++ b/lib/features/swipe_photo/swipe_photo_controller.dart
@@ -38,13 +38,13 @@ final photoCountProvider =
   _PhotoCountNotifier.new,
 );
 
-/// ご飯の登録数を取得するProvider
+/// グルメの登録数を取得するProvider
 /// 分類完了後の 「追加された写真 ＋XXX枚」に使用
 class _FoodPhotoCountNotifier extends AutoDisposeAsyncNotifier<int> {
   @override
   Future<int> build() async {
     // 取得できない場合はデフォルト値設定
-    return ref.read(localPhotoRepositoryProvider).getPhotoCount();
+    return ref.read(localPhotoRepositoryProvider).getFoodTotal();
   }
 }
 

--- a/lib/view/swipe_photo_page.dart
+++ b/lib/view/swipe_photo_page.dart
@@ -201,7 +201,7 @@ class SwipePhotoPageState extends ConsumerState<SwipePhotoPage> {
                       ?.copyWith(color: Themes.gray.shade400),
                 ),
                 const Gap(8),
-                ref.watch(foodPhotoCountProvider).when(
+                ref.watch(foodPhotoTotalProvider).when(
                       data: (count) {
                         return Row(
                           mainAxisAlignment: MainAxisAlignment.center,


### PR DESCRIPTION
## 関連のタスク issue
<!-- Notionリンクを記載  -->
https://www.notion.so/masakisato/10fe553f70274cb8be057ef3cb4fdc44?pvs=4

## 対応したこと
<!-- 実装の概要を箇条書きする  -->
- 完了画面で表示される枚数を、追加で保存した差分の枚数が表示されるようにしました。
  - スワイプ完了時にグルメの枚数をDBに保存するようにしました。

## 未解決事項
<!-- 別PRで対応するような状況があれば記載  -->  

- なし

## 実際の挙動
<!-- UIに関わるようであればスクリーンショット、動きのあるものは動画 or GIF  -->  
<!-- 入力エリアにドラッグ&ドロップしてアップロード  -->
![Screenshot_1716688268](https://github.com/schwarzwald0906/My_Gourmet/assets/103257145/24424c77-7fa7-432a-a1f6-8351f92e82da)
![Screenshot_1716688284](https://github.com/schwarzwald0906/My_Gourmet/assets/103257145/d05af77f-8640-4931-be81-a8e1b927e7b3)

## チェックリスト
<!-- 空白を消して`x`をつける  -->  
- [x] 実装完了後、問題が起こっていないか実際に動作確認したか  
- [x] 補足があった方が良い/重点的にレビューが欲しい箇所にGitHub上でコメントをしたか

## その他コメント

<!-- 何かあれば！  -->
