### PR TITLE
ハードコードで店舗情報登録用メソッドを追加

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
     <uses-permission android:name="android.permission.READ_MEDIA_VISUAL_USER_SELECTED" />
 
     <application
-            android:label="@string/app_name"
+        android:label="@string/app_name"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity
@@ -40,5 +40,9 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+        <!-- Add the Google Sign-In API key here -->
+        <meta-data
+            android:name="com.google.android.gms.auth.api.signin.API_KEY"
+            android:value="864724760472-ngamh59ivicfmhaei4bm0saonr1l4lsc.apps.googleusercontent.com"/>
     </application>
 </manifest>

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -40,9 +40,5 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
-        <!-- Add the Google Sign-In API key here -->
-        <meta-data
-            android:name="com.google.android.gms.auth.api.signin.API_KEY"
-            android:value="864724760472-ngamh59ivicfmhaei4bm0saonr1l4lsc.apps.googleusercontent.com"/>
     </application>
 </manifest>

--- a/lib/features/auth/auth_repository.dart
+++ b/lib/features/auth/auth_repository.dart
@@ -48,7 +48,6 @@ class AuthRepository {
       scopes: [
         'profile',
         'email',
-        'https://www.googleapis.com/auth/photoslibrary',
       ],
     ).signIn();
 

--- a/lib/features/photo/photo_controller.dart
+++ b/lib/features/photo/photo_controller.dart
@@ -28,12 +28,12 @@ class PhotoController {
     await _authRepository.upsertClassifyPhotosStatus(userId);
   }
 
-  /// 写真アップロード用メソッド
-  Future<void> uploadPhotos({
+  /// 写真の店舗情報登録用メソッド
+  Future<void> registerStoreInfo({
     required String accessToken,
     required String userId,
   }) async {
-    await _photoRepository.callClassifyPhotos(
+    await _photoRepository.registerStoreInfo(
       accessToken,
       userId,
     );

--- a/lib/features/photo/photo_repository.dart
+++ b/lib/features/photo/photo_repository.dart
@@ -54,6 +54,9 @@ class PhotoRepository {
         },
         body: jsonEncode({
           'userId': userId,
+          'lat':35.446841666666664,
+          'lon':139.63788888888888,
+          'photo_id':'QLi6rfxJQ1Y0Hx7QELnWLsjq11z2',
         }),
       );
 

--- a/lib/features/photo/photo_repository.dart
+++ b/lib/features/photo/photo_repository.dart
@@ -44,10 +44,10 @@ class PhotoRepository {
   final String _apiUrl =
       flavor.isProd ? dotenv.env['PROD_API_URL']! : dotenv.env['DEV_API_URL']!;
 
-  Future<void> callClassifyPhotos(String accessToken, String userId) async {
+  Future<void> registerStoreInfo(String accessToken, String userId) async {
     try {
       final response = await http.post(
-        Uri.parse('$_apiUrl/classifyPhotos'),
+        Uri.parse('$_apiUrl/findNearbyRestaurants'),
         headers: {
           'Content-Type': 'application/json',
           'Authorization': 'Bearer $accessToken',

--- a/lib/features/photo/photo_repository.dart
+++ b/lib/features/photo/photo_repository.dart
@@ -54,9 +54,9 @@ class PhotoRepository {
         },
         body: jsonEncode({
           'userId': userId,
-          'lat':35.446841666666664,
-          'lon':139.63788888888888,
-          'photo_id':'QLi6rfxJQ1Y0Hx7QELnWLsjq11z2',
+          'lat': 35.446841666666664,
+          'lon': 139.63788888888888,
+          'photo_id': 'QLi6rfxJQ1Y0Hx7QELnWLsjq11z2',
         }),
       );
 

--- a/lib/view/my_page.dart
+++ b/lib/view/my_page.dart
@@ -16,7 +16,9 @@ class MyPage extends ConsumerWidget {
   // この後のプルリクで、下記のようにメソッドを切り出して呼び出す。
   // Future<void> _onButtonPressed() async {
   //   try {
-  //     final result = await ref.read(authControllerProvider).signInWithGoogle();
+  //     final result =
+  //     await ref
+  //        .read(authControllerProvider).signInWithGoogle();
   //     await ref
   //         .read(photoControllerProvider)
   //         .upsertClassifyPhotosStatus(userId: result.userId);

--- a/lib/view/my_page.dart
+++ b/lib/view/my_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../features/auth/auth_controller.dart';
+import '../features/photo/photo_controller.dart';
 import 'widgets/confirm_dialog.dart';
 import 'widgets/success_snack_bar.dart';
 
@@ -11,6 +12,28 @@ class MyPage extends ConsumerWidget {
 
   static const routeName = 'my_page';
   static const routePath = '/my_page';
+
+  // この後のプルリクで、下記のようにメソッドを切り出して呼び出す。
+  // Future<void> _onButtonPressed() async {
+  //   try {
+  //     final result = await ref.read(authControllerProvider).signInWithGoogle();
+  //     await ref
+  //         .read(photoControllerProvider)
+  //         .upsertClassifyPhotosStatus(userId: result.userId);
+  //     });
+  //     await ref.read(photoControllerProvider).uploadPhotos(
+  //           accessToken: result.accessToken,
+  //           userId: result.userId,
+  //         );
+  //   } on Exception catch (e) {
+  //     // 例外が発生した場合、エラーメッセージを表示
+  //     if (context.mounted) {
+  //       ScaffoldMessenger.of(context).showSnackBar(
+  //         SnackBar(content: Text(e.toString())),
+  //       );
+  //     }
+  //   }
+  // }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -23,6 +46,39 @@ class MyPage extends ConsumerWidget {
             Expanded(
               child: ListView(
                 children: [
+                  ListTile(
+                    onTap: () async {
+                      await ConfirmDialog.show(
+                        context,
+                        hasCancelButton: true,
+                        titleString: '注意',
+                        contentString: '本当に位置情報を取得しますか？',
+                        onConfirmed: () async {
+                          final result = await ref
+                              .read(authControllerProvider)
+                              .signInWithGoogle();
+                          await ref
+                              .read(photoControllerProvider)
+                              .upsertClassifyPhotosStatus(
+                                userId: result.userId,
+                              );
+                          await ref
+                              .read(photoControllerProvider)
+                              .registerStoreInfo(
+                                accessToken: result.accessToken,
+                                userId: result.userId,
+                              );
+                          if (context.mounted) {
+                            SuccessSnackBar.show(
+                              context,
+                              message: '位置情報を取得しました',
+                            );
+                          }
+                        },
+                      );
+                    },
+                    title: const Text('   位置情報を取得'),
+                  ),
                   ListTile(
                     onTap: () async {
                       await ConfirmDialog.show(

--- a/lib/view/root_page.dart
+++ b/lib/view/root_page.dart
@@ -10,6 +10,7 @@ import 'package:url_launcher/url_launcher.dart';
 import '../core/shared_preferences_service.dart';
 import 'classify_start_page.dart';
 import 'home_page.dart';
+import 'my_page.dart';
 import 'onboarding_page.dart';
 import 'swipe_photo_page.dart';
 import 'widgets/confirm_dialog.dart';
@@ -146,15 +147,15 @@ class _NavigationFrame extends ConsumerWidget {
                   ),
                   label: 'ギャラリー',
                 ),
-                // BottomNavigationBarItem(
-                //   icon: Padding(
-                //     padding: EdgeInsets.only(top: 10),
-                //     child: Icon(
-                //       Icons.person,
-                //     ),
-                //   ),
-                //   label: 'マイページ',
-                // ),
+                BottomNavigationBarItem(
+                  icon: Padding(
+                    padding: EdgeInsets.only(top: 10),
+                    child: Icon(
+                      Icons.person,
+                    ),
+                  ),
+                  label: 'マイページ',
+                ),
               ],
             )
           : null,
@@ -171,7 +172,7 @@ class _NavigationFrame extends ConsumerWidget {
       SwipePhotoPage.routePath: 0,
       ClassifyStartPage.routePath: 0,
       HomePage.routePath: 1,
-      // MyPage.routePath: 2,
+      MyPage.routePath: 2,
     };
 
     return routeIndexMap.entries
@@ -196,8 +197,8 @@ class _NavigationFrame extends ConsumerWidget {
         );
       case 1:
         context.go(HomePage.routePath);
-      // case 2:
-      //   context.go(MyPage.routePath);
+      case 2:
+        context.go(MyPage.routePath);
     }
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -804,26 +804,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "78eb209deea09858f5269f5a5b02be4049535f568c07b275096836f01ea323fa"
+      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.0"
+    version: "10.0.4"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: b46c5e37c19120a8a01918cfaf293547f47269f7cb4b0058f21531c2465d6ef0
+      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.3"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: a597f72a664dbd293f3bfc51f9ba69816f84dcd403cdac7066cb3f6003f3ab47
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   lints:
     dependency: transitive
     description:
@@ -868,10 +868,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: d584fa6707a52763a52446f02cc621b077888fb63b93bbcb1143a7be5a0c0c04
+      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
       url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.12.0"
   mime:
     dependency: transitive
     description:
@@ -1249,10 +1249,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "5c2f730018264d276c20e4f1503fd1308dfbbae39ec8ee63c5236311ac06954b"
+      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.1"
+    version: "0.7.0"
   timing:
     dependency: transitive
     description:
@@ -1361,10 +1361,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: b3d56ff4341b8f182b96aceb2fa20e3dcb336b9f867bc0eafc0de10f1048e957
+      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
       url: "https://pub.dev"
     source: hosted
-    version: "13.0.0"
+    version: "14.2.1"
   watcher:
     dependency: transitive
     description:


### PR DESCRIPTION
## 関連のタスク issue
<!-- Notionリンクを記載  -->
https://www.notion.so/masakisato/Feature-Request-fe2f7cc7d0fb41afa1a9a53c41a80a16?pvs=4

## 対応したこと
<!-- 実装の概要を箇条書きする  -->
- 　マイページにメソッドを臨時的に生やした。
- 　今までの画像分類用の店舗登録用のエンドポイントに 修正した。
- 　google sign inの処理でandroid manifestに処理を追加した。 

## 未解決事項
<!-- 別PRで対応するような状況があれば記載  -->  
- ハードコードではなく、写真の位置情報とローカルDBのIDを元にリクエストする。
- メソッドを、マイページではなく、スワイプや、ギャラリー画面からタップする際に発火するように修正する。 

## 実際の挙動
<!-- UIに関わるようであればスクリーンショット、動きのあるものは動画 or GIF  -->  
 マイページに固定値で簡易的なAPIをリクエストするようにしました。
とりあえず、これ一回叩いてもらえれば、firestoreにデータが入るので、
firestoreからデータを取得するところ（店舗詳細画面の開発）を進めてもらえればと思います。

![image](https://github.com/schwarzwald0906/My_Gourmet/assets/93188453/38e5b216-4c89-4644-bc37-78128abd158d)


<!-- 入力エリアにドラッグ&ドロップしてアップロード  -->

## チェックリスト
<!-- 空白を消して`x`をつける  -->  
- [x] 実装完了後、問題が起こっていないか実際に動作確認したか  
- [x] 補足があった方が良い/重点的にレビューが欲しい箇所にGitHub上でコメントをしたか

## その他コメント

<!-- 何かあれば！  -->
