### PR TITLE
オンボーディング時に画像追加からスタートするように変更

### DIFF
--- a/lib/view/onboarding_page.dart
+++ b/lib/view/onboarding_page.dart
@@ -2,9 +2,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
 import 'package:smooth_page_indicator/smooth_page_indicator.dart';
+import 'package:go_router/go_router.dart';
 
 import '../core/build_context_extension.dart';
 import '../core/shared_preferences_service.dart';
+import 'swipe_photo_page.dart';
 import 'widgets/custom_elevated_button.dart';
 
 /// オンボーディング完了フラグ用[StateProvider]
@@ -136,6 +138,7 @@ class _OnboardingPageState extends ConsumerState<OnboardingPage> {
                             ref
                                 .read(isOnBoardingCompletedProvider.notifier)
                                 .update((state) => true);
+                            context.go(SwipePhotoPage.routePath);
                           }
                         },
                         text: isLastPage ? 'やってみる' : 'つぎへ',

--- a/lib/view/onboarding_page.dart
+++ b/lib/view/onboarding_page.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
-import 'package:smooth_page_indicator/smooth_page_indicator.dart';
 import 'package:go_router/go_router.dart';
+import 'package:smooth_page_indicator/smooth_page_indicator.dart';
 
 import '../core/build_context_extension.dart';
 import '../core/shared_preferences_service.dart';

--- a/lib/view/root_page.dart
+++ b/lib/view/root_page.dart
@@ -112,26 +112,54 @@ class _RootPageState extends ConsumerState<RootPage> {
 }
 
 /// [BottomNavigationBar]を用いてページ遷移を管理するクラス
-class _NavigationFrame extends ConsumerWidget {
+class _NavigationFrame extends ConsumerStatefulWidget {
   const _NavigationFrame({required this.child});
 
   final Widget child;
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
+  _NavigationFrameState createState() => _NavigationFrameState();
+}
+
+class _NavigationFrameState extends ConsumerState<_NavigationFrame> {
+  int _selectedIndex = 0;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      final isOnboardingComplete = ref.read(isOnBoardingCompletedProvider);
+      if (isOnboardingComplete) {
+        setState(() {
+          _selectedIndex = 0; // 画像追加タブを選択
+        });
+      }
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
     final isClassifyOnboardingCompleted =
         ref.watch(isClassifyOnboardingCompletedProvider);
 
     final isOnboardingComplete = ref.watch(isOnBoardingCompletedProvider);
 
     return Scaffold(
-      body: child,
+      body: Stack(
+        children: [
+          widget.child,
+          if (!isOnboardingComplete) const OnboardingPage(),
+        ],
+      ),
       bottomNavigationBar: isOnboardingComplete
           ? BottomNavigationBar(
-              currentIndex:
-                  _calcSelectedIndex(context, isClassifyOnboardingCompleted),
-              onTap: (int index) =>
-                  _onItemTapped(index, context, isClassifyOnboardingCompleted),
+              currentIndex: _selectedIndex,
+              onTap: (int index) {
+                setState(() {
+                  _selectedIndex = index;
+                });
+                _onItemTapped(index, context, isClassifyOnboardingCompleted);
+              },
               items: const [
                 BottomNavigationBarItem(
                   icon: Padding(
@@ -164,27 +192,6 @@ class _NavigationFrame extends ConsumerWidget {
             )
           : null,
     );
-  }
-
-  int _calcSelectedIndex(
-    BuildContext context,
-    bool isClassifyOnboardingCompleted,
-  ) {
-    final location = GoRouterState.of(context).uri.toString();
-
-    const routeIndexMap = {
-      SwipePhotoPage.routePath: 0,
-      ClassifyStartPage.routePath: 0,
-      HomePage.routePath: 1,
-      MyPage.routePath: 2,
-    };
-
-    return routeIndexMap.entries
-        .firstWhere(
-          (entry) => location.contains(entry.key),
-          orElse: () => throw UnimplementedError(),
-        )
-        .value;
   }
 
   void _onItemTapped(

--- a/lib/view/root_page.dart
+++ b/lib/view/root_page.dart
@@ -112,54 +112,26 @@ class _RootPageState extends ConsumerState<RootPage> {
 }
 
 /// [BottomNavigationBar]を用いてページ遷移を管理するクラス
-class _NavigationFrame extends ConsumerStatefulWidget {
+class _NavigationFrame extends ConsumerWidget {
   const _NavigationFrame({required this.child});
 
   final Widget child;
 
   @override
-  _NavigationFrameState createState() => _NavigationFrameState();
-}
-
-class _NavigationFrameState extends ConsumerState<_NavigationFrame> {
-  int _selectedIndex = 0;
-
-  @override
-  void initState() {
-    super.initState();
-    WidgetsBinding.instance.addPostFrameCallback((_) {
-      final isOnboardingComplete = ref.read(isOnBoardingCompletedProvider);
-      if (isOnboardingComplete) {
-        setState(() {
-          _selectedIndex = 0; // 画像追加タブを選択
-        });
-      }
-    });
-  }
-
-  @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     final isClassifyOnboardingCompleted =
         ref.watch(isClassifyOnboardingCompletedProvider);
 
     final isOnboardingComplete = ref.watch(isOnBoardingCompletedProvider);
 
     return Scaffold(
-      body: Stack(
-        children: [
-          widget.child,
-          if (!isOnboardingComplete) const OnboardingPage(),
-        ],
-      ),
+      body: child,
       bottomNavigationBar: isOnboardingComplete
           ? BottomNavigationBar(
-              currentIndex: _selectedIndex,
-              onTap: (int index) {
-                setState(() {
-                  _selectedIndex = index;
-                });
-                _onItemTapped(index, context, isClassifyOnboardingCompleted);
-              },
+              currentIndex:
+                  _calcSelectedIndex(context, isClassifyOnboardingCompleted),
+              onTap: (int index) =>
+                  _onItemTapped(index, context, isClassifyOnboardingCompleted),
               items: const [
                 BottomNavigationBarItem(
                   icon: Padding(
@@ -192,6 +164,27 @@ class _NavigationFrameState extends ConsumerState<_NavigationFrame> {
             )
           : null,
     );
+  }
+
+  int _calcSelectedIndex(
+    BuildContext context,
+    bool isClassifyOnboardingCompleted,
+  ) {
+    final location = GoRouterState.of(context).uri.toString();
+
+    const routeIndexMap = {
+      SwipePhotoPage.routePath: 0,
+      ClassifyStartPage.routePath: 0,
+      HomePage.routePath: 1,
+      MyPage.routePath: 2,
+    };
+
+    return routeIndexMap.entries
+        .firstWhere(
+          (entry) => location.contains(entry.key),
+          orElse: () => throw UnimplementedError(),
+        )
+        .value;
   }
 
   void _onItemTapped(


### PR DESCRIPTION
## 関連のタスク issue
<!-- Notionリンクを記載  -->
https://www.notion.so/masakisato/0343d767da0d4762b924f31464b4d162
## 対応したこと
<!-- 実装の概要を箇条書きする  -->
- オンボーディング終了時、画像追加タブからスタートするように修正。

## 未解決事項
<!-- 別PRで対応するような状況があれば記載  -->  

- なし

## 実際の挙動
<!-- UIに関わるようであればスクリーンショット、動きのあるものは動画 or GIF  -->
オンボーディング終了時
![スクリーンショット 2024-06-22 13 37 52](https://github.com/schwarzwald0906/My_Gourmet/assets/108531104/349db600-6918-4ac3-9b3c-3630fb3849d1)

  
<!-- 入力エリアにドラッグ&ドロップしてアップロード  -->

## チェックリスト
<!-- 空白を消して`x`をつける  -->  
- [x] 実装完了後、問題が起こっていないか実際に動作確認したか  
- [x] 補足があった方が良い/重点的にレビューが欲しい箇所にGitHub上でコメントをしたか

## その他コメント

<!-- 何かあれば！  -->
