### PR TITLE
カテゴリ分類機能を実装

### DIFF
--- a/lib/features/photo/photo_repository.dart
+++ b/lib/features/photo/photo_repository.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:typed_data';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
@@ -79,7 +80,37 @@ class PhotoRepository {
     }
   }
 
-  // TODO(masaki): firestoreへデータ作成後に動作確認 & 全件取得ではない取得方法検討
+  Future<void> categorizeFood({
+    required String userId,
+    required String photoId,
+    required Uint8List photoData,
+  }) async {
+    try {
+      final response = await http.post(
+        Uri.parse('$_apiUrl/categorizeFood'),
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: jsonEncode({
+          'userId': userId,
+          'photoId': photoId,
+          'photo': base64Encode(photoData),
+        }),
+      );
+
+      if (response.statusCode == 200) {
+        // 成功した場合の処理
+        debugPrint('API call successful: ${response.body}');
+      } else {
+        // エラーが返された場合の処理
+        debugPrint('API call failed: ${response.body}');
+      }
+    } on Exception catch (error) {
+      logger.e(error.toString());
+    }
+  }
+
+  // TODO: firestoreへデータ作成後に動作確認 & 全件取得ではない取得方法検討
   Future<List<Photo>> downloadPhotos({
     required String userId,
   }) async {

--- a/lib/features/photo/photo_repository.dart
+++ b/lib/features/photo/photo_repository.dart
@@ -110,7 +110,7 @@ class PhotoRepository {
     }
   }
 
-  // TODO: firestoreへデータ作成後に動作確認 & 全件取得ではない取得方法検討
+  // TODO(firestore): データ作成後に動作確認 & 全件取得ではない取得方法検討
   Future<List<Photo>> downloadPhotos({
     required String userId,
   }) async {

--- a/lib/features/swipe_photo/swipe_photo_controller.dart
+++ b/lib/features/swipe_photo/swipe_photo_controller.dart
@@ -130,7 +130,7 @@ class _PhotoListNotifier extends AutoDisposeAsyncNotifier<List<AssetEntity>> {
         unawaited(
           photo.file.then((value) async {
             // 画像を圧縮
-            final compressedData = await compressImage(value!);
+            final compressedData = await _compressImage(value!);
             if (compressedData != null) {
               await ref.read(photoRepositoryProvider).categorizeFood(
                     userId: result.userId,
@@ -221,12 +221,13 @@ class _PhotoListNotifier extends AutoDisposeAsyncNotifier<List<AssetEntity>> {
   }
 
   /// 画像を圧縮するメソッド
-  Future<Uint8List?> compressImage(File file) async {
+  Future<Uint8List?> _compressImage(File file) async {
     final result = await FlutterImageCompress.compressWithFile(
       file.absolute.path,
       minWidth: 256,
       minHeight: 256,
       quality: 85,
+      keepExif: true,
     );
     return result;
   }

--- a/lib/features/swipe_photo/swipe_photo_controller.dart
+++ b/lib/features/swipe_photo/swipe_photo_controller.dart
@@ -1,14 +1,18 @@
 import 'dart:async';
+import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:exif/exif.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_image_compress/flutter_image_compress.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:photo_manager/photo_manager.dart';
 
 import '../../core/exception.dart';
 import '../../core/local_photo_repository.dart';
 import '../../core/photo_manager_service.dart';
+import '../../logger.dart';
 import '../auth/auth_controller.dart';
 import '../photo/photo_repository.dart';
 import 'photo_count.dart';
@@ -122,12 +126,27 @@ class _PhotoListNotifier extends AutoDisposeAsyncNotifier<List<AssetEntity>> {
             }
           }),
         );
+
+        unawaited(
+          photo.file.then((value) async {
+            // 画像を圧縮
+            final compressedData = await compressImage(value!);
+            if (compressedData != null) {
+              await ref.read(photoRepositoryProvider).categorizeFood(
+                    userId: result.userId,
+                    photoId: photo.id,
+                    photoData: compressedData,
+                  );
+            }
+          }),
+        );
       }
 
       // カウント更新
       ref.read(photoCountProvider.notifier).updateCurrentCount();
     } on Exception catch (e, stacktrace) {
       state = AsyncValue.error(e, stacktrace);
+      logger.e('Error loading next: $e');
       return;
     }
 
@@ -156,7 +175,7 @@ class _PhotoListNotifier extends AutoDisposeAsyncNotifier<List<AssetEntity>> {
     }
   }
 
-  ///　強制リフレッシュ
+  /// 強制リフレッシュ
   void forceRefresh() {
     state = const AsyncLoading<List<AssetEntity>>();
     ref.invalidateSelf();
@@ -199,6 +218,17 @@ class _PhotoListNotifier extends AutoDisposeAsyncNotifier<List<AssetEntity>> {
     } on Exception catch (_) {
       return null;
     }
+  }
+
+  /// 画像を圧縮するメソッド
+  Future<Uint8List?> compressImage(File file) async {
+    final result = await FlutterImageCompress.compressWithFile(
+      file.absolute.path,
+      minWidth: 256,
+      minHeight: 256,
+      quality: 85,
+    );
+    return result;
   }
 }
 

--- a/lib/view/my_page.dart
+++ b/lib/view/my_page.dart
@@ -12,30 +12,6 @@ class MyPage extends ConsumerWidget {
   static const routeName = 'my_page';
   static const routePath = '/my_page';
 
-  // この後のプルリクで、下記のようにメソッドを切り出して呼び出す。
-  // Future<void> _onButtonPressed() async {
-  //   try {
-  //     final result =
-  //     await ref
-  //        .read(authControllerProvider).signInWithGoogle();
-  //     await ref
-  //         .read(photoControllerProvider)
-  //         .upsertClassifyPhotosStatus(userId: result.userId);
-  //     });
-  //     await ref.read(photoControllerProvider).uploadPhotos(
-  //           accessToken: result.accessToken,
-  //           userId: result.userId,
-  //         );
-  //   } on Exception catch (e) {
-  //     // 例外が発生した場合、エラーメッセージを表示
-  //     if (context.mounted) {
-  //       ScaffoldMessenger.of(context).showSnackBar(
-  //         SnackBar(content: Text(e.toString())),
-  //       );
-  //     }
-  //   }
-  // }
-
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -574,6 +574,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.20.5"
+  flutter_image_compress:
+    dependency: "direct main"
+    description:
+      name: flutter_image_compress
+      sha256: "37f1b26399098e5f97b74c1483f534855e7dff68ead6ddaccf747029fb03f29f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.3"
   flutter_launcher_icons:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   flutter:
     sdk: flutter
   flutter_dotenv: ^5.1.0
+  flutter_image_compress: ^1.1.0
   flutter_launcher_icons: ^0.13.1
   flutter_riverpod: ^2.4.4
   flutter_staggered_grid_view: ^0.7.0


### PR DESCRIPTION
## 関連のタスク issue
<!-- Notionリンクを記載  -->
https://www.notion.so/masakisato/firestore-551cc0e06dd54960aae6fff84bdb1b26?pvs=4

## 対応したこと
<!-- 実装の概要を箇条書きする  -->
- カテゴリ分類機能を実行するAPIをリクエスト

## 未解決事項
<!-- 別PRで対応するような状況があれば記載  -->  
- 下記を別プルリクエストで対応
- https://www.notion.so/masakisato/firestore-UI-ba7925b569bd41b59eba84bc7d961c60?pvs=4

- なし

## 実際の挙動
<!-- UIに関わるようであればスクリーンショット、動きのあるものは動画 or GIF  -->  
photosの配下にimage_url（画像の保存パス）とcategoryというフィールドを追加しました。

![CleanShot 2024-07-24 at 19 20 13](https://github.com/user-attachments/assets/22be4654-c2f7-4e16-8522-1dfa282d0f87)

<!-- 入力エリアにドラッグ&ドロップしてアップロード  -->

## チェックリスト
<!-- 空白を消して`x`をつける  -->  
- [x] 実装完了後、問題が起こっていないか実際に動作確認したか  
- [x] 補足があった方が良い/重点的にレビューが欲しい箇所にGitHub上でコメントをしたか

## その他コメント

<!-- 何かあれば！  -->
