### PR TITLE
firestoreの値を元にUI上で切り替えられる

### DIFF
--- a/lib/core/router.dart
+++ b/lib/core/router.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -48,8 +46,6 @@ final routerProvider = Provider(
         builder: (context, state) {
           final args = state.extra! as Map<String, dynamic>;
           return ImageDetailPage(
-            heroImageFile: args['heroImageFile'] as File,
-            photoFileList: args['photoFileList'] as List<File>,
             index: args['index'] as int,
             photoUrl: args['photoUrl'] as String,
           );

--- a/lib/core/router.dart
+++ b/lib/core/router.dart
@@ -51,6 +51,7 @@ final routerProvider = Provider(
             heroImageFile: args['heroImageFile'] as File,
             photoFileList: args['photoFileList'] as List<File>,
             index: args['index'] as int,
+            photoUrl: args['photoUrl'] as String,
           );
         },
       ),

--- a/lib/features/photo/photo.dart
+++ b/lib/features/photo/photo.dart
@@ -24,6 +24,9 @@ class Photo with _$Photo {
     /// FirebaseStorageに保存された写真のURL
     @Default('') String url,
 
+    /// geminiで推論した写真のカテゴリ
+    @Default('') String category,
+
     /// FirebaseStorageのドキュメントID
     @Default('') String userId,
 

--- a/lib/features/photo/photo.dart
+++ b/lib/features/photo/photo.dart
@@ -25,6 +25,8 @@ class Photo with _$Photo {
     @Default('') String url,
 
     /// geminiで推論した写真のカテゴリ
+    /// ここをstringではなくてenumに変換して格納しておくと、
+    /// Flutter上では型安全に扱えて想定外の実行時エラーが防げるため修正したい
     @Default('') String category,
 
     /// FirebaseStorageのドキュメントID

--- a/lib/features/photo/photo.freezed.dart
+++ b/lib/features/photo/photo.freezed.dart
@@ -34,6 +34,9 @@ mixin _$Photo {
   /// FirebaseStorageに保存された写真のURL
   String get url => throw _privateConstructorUsedError;
 
+  /// geminiで推論した写真のカテゴリ
+  String get category => throw _privateConstructorUsedError;
+
   /// FirebaseStorageのドキュメントID
   String get userId => throw _privateConstructorUsedError;
 
@@ -56,6 +59,7 @@ abstract class $PhotoCopyWith<$Res> {
       @timestampConverter UnionTimestamp createdAt,
       @serverTimestampConverter UnionTimestamp updatedAt,
       String url,
+      String category,
       String userId,
       @timestampConverter UnionTimestamp shotAt});
 
@@ -81,6 +85,7 @@ class _$PhotoCopyWithImpl<$Res, $Val extends Photo>
     Object? createdAt = null,
     Object? updatedAt = null,
     Object? url = null,
+    Object? category = null,
     Object? userId = null,
     Object? shotAt = null,
   }) {
@@ -100,6 +105,10 @@ class _$PhotoCopyWithImpl<$Res, $Val extends Photo>
       url: null == url
           ? _value.url
           : url // ignore: cast_nullable_to_non_nullable
+              as String,
+      category: null == category
+          ? _value.category
+          : category // ignore: cast_nullable_to_non_nullable
               as String,
       userId: null == userId
           ? _value.userId
@@ -149,6 +158,7 @@ abstract class _$$PhotoImplCopyWith<$Res> implements $PhotoCopyWith<$Res> {
       @timestampConverter UnionTimestamp createdAt,
       @serverTimestampConverter UnionTimestamp updatedAt,
       String url,
+      String category,
       String userId,
       @timestampConverter UnionTimestamp shotAt});
 
@@ -175,6 +185,7 @@ class __$$PhotoImplCopyWithImpl<$Res>
     Object? createdAt = null,
     Object? updatedAt = null,
     Object? url = null,
+    Object? category = null,
     Object? userId = null,
     Object? shotAt = null,
   }) {
@@ -194,6 +205,10 @@ class __$$PhotoImplCopyWithImpl<$Res>
       url: null == url
           ? _value.url
           : url // ignore: cast_nullable_to_non_nullable
+              as String,
+      category: null == category
+          ? _value.category
+          : category // ignore: cast_nullable_to_non_nullable
               as String,
       userId: null == userId
           ? _value.userId
@@ -217,6 +232,7 @@ class _$PhotoImpl extends _Photo {
       @serverTimestampConverter
       this.updatedAt = const UnionTimestamp.serverTimestamp(),
       this.url = '',
+      this.category = '',
       this.userId = '',
       @timestampConverter this.shotAt = const UnionTimestamp.serverTimestamp()})
       : super._();
@@ -246,6 +262,11 @@ class _$PhotoImpl extends _Photo {
   @JsonKey()
   final String url;
 
+  /// FirebaseStorageに保存された写真のURL
+  @override
+  @JsonKey()
+  final String category;
+
   /// FirebaseStorageのドキュメントID
   @override
   @JsonKey()
@@ -259,7 +280,7 @@ class _$PhotoImpl extends _Photo {
 
   @override
   String toString() {
-    return 'Photo(id: $id, createdAt: $createdAt, updatedAt: $updatedAt, url: $url, userId: $userId, shotAt: $shotAt)';
+    return 'Photo(id: $id, createdAt: $createdAt, updatedAt: $updatedAt, url: $url, category: $category, userId: $userId, shotAt: $shotAt)';
   }
 
   @override
@@ -273,14 +294,16 @@ class _$PhotoImpl extends _Photo {
             (identical(other.updatedAt, updatedAt) ||
                 other.updatedAt == updatedAt) &&
             (identical(other.url, url) || other.url == url) &&
+            (identical(other.category, category) ||
+                other.category == category) &&
             (identical(other.userId, userId) || other.userId == userId) &&
             (identical(other.shotAt, shotAt) || other.shotAt == shotAt));
   }
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode =>
-      Object.hash(runtimeType, id, createdAt, updatedAt, url, userId, shotAt);
+  int get hashCode => Object.hash(
+      runtimeType, id, createdAt, updatedAt, url, category, userId, shotAt);
 
   @JsonKey(ignore: true)
   @override
@@ -302,6 +325,7 @@ abstract class _Photo extends Photo {
       @timestampConverter final UnionTimestamp createdAt,
       @serverTimestampConverter final UnionTimestamp updatedAt,
       final String url,
+      final String category,
       final String userId,
       @timestampConverter final UnionTimestamp shotAt}) = _$PhotoImpl;
   const _Photo._() : super._();
@@ -326,6 +350,10 @@ abstract class _Photo extends Photo {
 
   /// FirebaseStorageに保存された写真のURL
   String get url;
+  @override
+
+  /// geminiで推論した写真のカテゴリ
+  String get category;
   @override
 
   /// FirebaseStorageのドキュメントID

--- a/lib/features/photo/photo.g.dart
+++ b/lib/features/photo/photo.g.dart
@@ -15,6 +15,7 @@ _$PhotoImpl _$$PhotoImplFromJson(Map<String, dynamic> json) => _$PhotoImpl(
           ? const UnionTimestamp.serverTimestamp()
           : serverTimestampConverter.fromJson(json['updatedAt'] as Object),
       url: json['url'] as String? ?? '',
+      category: json['category'] as String? ?? '',
       userId: json['userId'] as String? ?? '',
       shotAt: json['shotAt'] == null
           ? const UnionTimestamp.serverTimestamp()
@@ -27,6 +28,7 @@ Map<String, dynamic> _$$PhotoImplToJson(_$PhotoImpl instance) =>
       'createdAt': timestampConverter.toJson(instance.createdAt),
       'updatedAt': serverTimestampConverter.toJson(instance.updatedAt),
       'url': instance.url,
+      'category': instance.category,
       'userId': instance.userId,
       'shotAt': timestampConverter.toJson(instance.shotAt),
     };

--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -4,10 +4,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 import 'package:go_router/go_router.dart';
 
-import '../core/database/database.dart';
 import '../features/auth/auth_controller.dart';
 import '../features/auth/authed_user.dart';
-import '../features/home/home_controller.dart';
 import '../features/photo/photo_controller.dart';
 
 class HomePage extends ConsumerStatefulWidget {
@@ -22,8 +20,6 @@ class HomePage extends ConsumerStatefulWidget {
 
 class _HomePageState extends ConsumerState<HomePage>
     with SingleTickerProviderStateMixin {
-  late Future<List<Photo>> _photos;
-  late Future<List<Size>> _sizes;
   late TabController _tabController;
   bool isLoading = false;
   bool isReady = false;
@@ -31,7 +27,6 @@ class _HomePageState extends ConsumerState<HomePage>
   @override
   void initState() {
     super.initState();
-    _photos = ref.read(homeControllerProvider).getPhotos();
     _tabController = TabController(length: 6, vsync: this);
     _initDownloadPhotos();
   }

--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -96,7 +96,9 @@ class _HomePageState extends ConsumerState<HomePage>
                 // padding: const EdgeInsets.only(left: 0, right: 0), //,
                 tabAlignment: TabAlignment.start,
                 labelPadding: const EdgeInsets.only(
-                    left: 12.0, right: 12.0), // ここでラベルの左側のパディングを調整
+                  left: 12,
+                  right: 12,
+                ), // ここでラベルの左側のパディングを調整
                 tabs: const [
                   Tab(text: 'すべて'),
                   Tab(text: 'ラーメン'),
@@ -160,7 +162,7 @@ class _HomePageState extends ConsumerState<HomePage>
                   },
                 );
               },
-              child: Container(
+              child: DecoratedBox(
                 decoration: BoxDecoration(
                   border: Border.all(
                     color: Colors.grey,

--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 import '../features/auth/auth_controller.dart';
 import '../features/auth/authed_user.dart';
 import '../features/photo/photo_controller.dart';
+import 'image_detail_page.dart';
 
 class HomePage extends ConsumerStatefulWidget {
   const HomePage({super.key});
@@ -92,10 +93,10 @@ class _HomePageState extends ConsumerState<HomePage>
               child: TabBar(
                 controller: _tabController,
                 isScrollable: true,
+                // padding: const EdgeInsets.only(left: 0, right: 0), //,
+                tabAlignment: TabAlignment.start,
                 labelPadding: const EdgeInsets.only(
-                    left: 0.0, right: 20.0), // ここでラベルの左側のパディングを調整
-                indicatorPadding: const EdgeInsets.only(
-                    left: 0.0, right: 20.0), // インジケーターの左側のパディングを調整
+                    left: 12.0, right: 12.0), // ここでラベルの左側のパディングを調整
                 tabs: const [
                   Tab(text: 'すべて'),
                   Tab(text: 'ラーメン'),
@@ -152,7 +153,7 @@ class _HomePageState extends ConsumerState<HomePage>
             child: GestureDetector(
               onTap: () {
                 context.push(
-                  '/image_detail',
+                  ImageDetailPage.routePath,
                   extra: {
                     'photoUrl': photoUrl,
                     'index': index,

--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -1,12 +1,14 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 import 'package:go_router/go_router.dart';
 
 import '../core/database/database.dart';
+import '../features/auth/auth_controller.dart';
+import '../features/auth/authed_user.dart';
 import '../features/home/home_controller.dart';
+import '../features/photo/photo_controller.dart';
 
 class HomePage extends ConsumerStatefulWidget {
   const HomePage({super.key});
@@ -18,154 +20,160 @@ class HomePage extends ConsumerStatefulWidget {
   ConsumerState<HomePage> createState() => _HomePageState();
 }
 
-class _HomePageState extends ConsumerState<HomePage> {
+class _HomePageState extends ConsumerState<HomePage>
+    with SingleTickerProviderStateMixin {
   late Future<List<Photo>> _photos;
   late Future<List<Size>> _sizes;
+  late TabController _tabController;
+  bool isLoading = false;
+  bool isReady = false;
 
   @override
   void initState() {
     super.initState();
     _photos = ref.read(homeControllerProvider).getPhotos();
+    _tabController = TabController(length: 6, vsync: this);
+    _initDownloadPhotos();
+  }
+
+  Future<void> _initDownloadPhotos() async {
+    debugPrint('_initDownloadPhotos start!!!');
+
+    SchedulerBinding.instance.addPostFrameCallback((_) async {
+      final isSignedIn = ref.watch(userIdProvider) != null;
+      if (!isSignedIn) {
+        setState(() => isReady = true);
+        return;
+      }
+      await ref.watch(authedUserStreamProvider.future);
+      final authedUserAsync = ref.watch(authedUserStreamProvider).valueOrNull;
+      final isReadyForUse = authedUserAsync?.classifyPhotosStatus ==
+          ClassifyPhotosStatus.readyForUse;
+      if (!isReadyForUse) {
+        setState(() => isReady = true);
+        return;
+      }
+
+      await _downloadPhotos(ref);
+      setState(() => isReady = true);
+    });
+  }
+
+  List<String>? photoUrls; // Firebaseからダウンロードした写真のURLを保持
+
+  Future<void> _downloadPhotos(WidgetRef ref) async {
+    debugPrint('_downloadPhotos start!!!');
+    final userId = ref.watch(userIdProvider);
+
+    if (userId == null) {
+      debugPrint('User is not signed in');
+      return;
+    }
+
+    final result = await ref.read(photoControllerProvider).downloadPhotos(
+          userId: userId,
+        );
+
+    setState(() {
+      photoUrls =
+          result.map((e) => e.url).where((url) => url.isNotEmpty).toList();
+      debugPrint('photoUrls: $photoUrls');
+    });
   }
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      body: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 16),
-        child: FutureBuilder<List<Photo>>(
-          future: _photos,
-          builder: (context, snapshot) {
-            if (snapshot.connectionState == ConnectionState.waiting) {
-              return const Center(child: CircularProgressIndicator());
-            } else if (snapshot.hasError) {
-              return const Center(child: Text('エラーが発生しました'));
-            } else if (snapshot.hasData) {
-              _sizes = ref
-                  .read(homeControllerProvider)
-                  .calculateSizes(snapshot.data!);
-              return FutureBuilder<List<Size>>(
-                future: _sizes,
-                builder: (context, sizeSnapshot) {
-                  if (sizeSnapshot.connectionState == ConnectionState.waiting) {
-                    return const CircularProgressIndicator();
-                  } else if (sizeSnapshot.hasError) {
-                    return const Center(child: Text('エラーが発生しました'));
-                  } else if (sizeSnapshot.hasData) {
-                    if (snapshot.data!.isEmpty) {
-                      return Center(
-                        child: Column(
-                          mainAxisAlignment: MainAxisAlignment.center,
-                          children: [
-                            Image.asset(
-                              'assets/images/no_photo.png',
-                              width: 200,
-                            ),
-                            const SizedBox(height: 16),
-                            Text(
-                              '保存された写真がまだありません...',
-                              style: Theme.of(context).textTheme.titleSmall,
-                            ),
-                          ],
-                        ),
-                      );
-                    }
-                    return MasonryGridView.count(
-                      crossAxisCount: 2,
-                      mainAxisSpacing: 8,
-                      crossAxisSpacing: 8,
-                      itemBuilder: (context, index) {
-                        final photo = snapshot.data![index];
-                        final photoList =
-                            snapshot.data!.map((e) => File(e.path)).toList();
-                        final size = sizeSnapshot.data![index];
-
-                        return FutureBuilder<File>(
-                          future: ref
-                              .read(homeControllerProvider)
-                              .getFileByPhoto(photo),
-                          builder: (context, snapshot) {
-                            if (sizeSnapshot.hasError) {
-                              return const Center(child: Text('エラーが発生しました'));
-                            }
-                            if (snapshot.data == null) {
-                              return const CircularProgressIndicator();
-                            }
-
-                            return Hero(
-                              tag: photo.path,
-                              child: GestureDetector(
-                                onTap: () {
-                                  context.push(
-                                    '/image_detail',
-                                    extra: {
-                                      'heroImageFile': snapshot.data!,
-                                      'photoFileList': photoList,
-                                      'index': index,
-                                    },
-                                  );
-                                },
-                                child: Container(
-                                  width: size.width,
-                                  height: size.height,
-                                  decoration: BoxDecoration(
-                                    border: Border.all(
-                                      color: Colors.grey,
-                                      width: 2,
-                                    ),
-                                    borderRadius: BorderRadius.circular(16),
-                                  ),
-                                  child: ClipRRect(
-                                    borderRadius: BorderRadius.circular(14),
-                                    child: Image.file(
-                                      snapshot.data!,
-                                      fit: BoxFit.cover,
-                                    ),
-                                  ),
-                                ),
-                              ),
-                            );
-                          },
-                        );
-                      },
-                      itemCount: snapshot.data!.length,
-                    );
-                  } else {
-                    return Column(
-                      mainAxisAlignment: MainAxisAlignment.center,
-                      children: [
-                        Image.asset(
-                          'assets/images/no_photo.png',
-                          width: 200,
-                        ),
-                        const SizedBox(height: 16),
-                        Text(
-                          '保存された写真がまだありません...',
-                          style: Theme.of(context).textTheme.titleSmall,
-                        ),
-                      ],
-                    );
-                  }
-                },
-              );
-            } else {
-              return Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Image.asset(
-                    'assets/images/no_photo.png',
-                    width: 200,
-                  ),
-                  const SizedBox(height: 16),
-                  Text(
-                    '保存された写真がまだありません...',
-                    style: Theme.of(context).textTheme.titleSmall,
-                  ),
+      appBar: PreferredSize(
+        preferredSize: const Size.fromHeight(kToolbarHeight),
+        child: AppBar(
+          bottom: PreferredSize(
+            preferredSize: const Size.fromHeight(0), // TabBarの高さを指定
+            child: Container(
+              alignment: Alignment.centerLeft, // TabBarを左に寄せる
+              child: TabBar(
+                controller: _tabController,
+                isScrollable: true,
+                labelPadding: const EdgeInsets.only(
+                    left: 0.0, right: 20.0), // ここでラベルの左側のパディングを調整
+                indicatorPadding: const EdgeInsets.only(
+                    left: 0.0, right: 20.0), // インジケーターの左側のパディングを調整
+                tabs: const [
+                  Tab(text: 'すべて'),
+                  Tab(text: 'ラーメン'),
+                  Tab(text: 'カフェ'),
+                  Tab(text: '和食'),
+                  Tab(text: '洋食'),
+                  Tab(text: 'エスニック'),
                 ],
-              );
-            }
-          },
+              ),
+            ),
+          ),
         ),
+      ),
+      body: DefaultTabController(
+        length: 6,
+        child: TabBarView(
+          controller: _tabController,
+          children: [
+            _buildPhotoGrid(context),
+            Container(child: Text('ラーメン')),
+            Container(child: Text('カフェ')),
+            Container(child: Text('和食')),
+            Container(child: Text('洋食')),
+            Container(child: Text('エスニック')),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildPhotoGrid(BuildContext context) {
+    if (photoUrls == null) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16),
+      child: MasonryGridView.count(
+        crossAxisCount: 2,
+        mainAxisSpacing: 8,
+        crossAxisSpacing: 8,
+        itemBuilder: (context, index) {
+          final photoUrl = photoUrls![index];
+          return Hero(
+            tag: photoUrl,
+            child: GestureDetector(
+              onTap: () {
+                context.push(
+                  '/image_detail',
+                  extra: {
+                    'heroImageFile': photoUrl,
+                    'photoFileList': photoUrls,
+                    'index': index,
+                  },
+                );
+              },
+              child: Container(
+                decoration: BoxDecoration(
+                  border: Border.all(
+                    color: Colors.grey,
+                    width: 2,
+                  ),
+                  borderRadius: BorderRadius.circular(16),
+                ),
+                child: ClipRRect(
+                  borderRadius: BorderRadius.circular(14),
+                  child: Image.network(
+                    photoUrl,
+                    fit: BoxFit.cover,
+                  ),
+                ),
+              ),
+            ),
+          );
+        },
+        itemCount: photoUrls!.length,
       ),
     );
   }

--- a/lib/view/image_detail/card_back.dart
+++ b/lib/view/image_detail/card_back.dart
@@ -94,7 +94,6 @@ class CardBack extends StatelessWidget {
                                 child: ClipRRect(
                                   borderRadius: BorderRadius.circular(8),
                                   child: ScalableImage(
-                                    imageFile: imageFileList[index],
                                     height: 200,
                                     width: 200,
                                   ),

--- a/lib/view/image_detail/card_back.dart
+++ b/lib/view/image_detail/card_back.dart
@@ -93,7 +93,7 @@ class CardBack extends StatelessWidget {
                                 padding: const EdgeInsets.only(right: 8),
                                 child: ClipRRect(
                                   borderRadius: BorderRadius.circular(8),
-                                  child: ScalableImage(
+                                  child: const ScalableImage(
                                     height: 200,
                                     width: 200,
                                   ),

--- a/lib/view/image_detail/card_front.dart
+++ b/lib/view/image_detail/card_front.dart
@@ -66,6 +66,7 @@ class CardFront extends StatelessWidget {
                             )
                           : ScalableImage(
                               imageFile: imageFile,
+                              photoUrl: photoUrl,
                               height: MediaQuery.of(context).size.height * 0.5,
                             ),
                       Text(formattedDate, style: context.textTheme.titleSmall),

--- a/lib/view/image_detail/card_front.dart
+++ b/lib/view/image_detail/card_front.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:gap/gap.dart';
 
@@ -10,15 +8,13 @@ import '../widgets/scalable_image.dart';
 class CardFront extends StatelessWidget {
   const CardFront({
     super.key,
-    this.heroImageFile,
-    required this.imageFile,
+    required this.photoUrl,
     required this.shopName,
     required this.dateTime,
     required this.address,
   });
 
-  final File? heroImageFile;
-  final File imageFile;
+  final String photoUrl;
   final String shopName;
   final DateTime dateTime;
   final String address;
@@ -55,20 +51,20 @@ class CardFront extends StatelessWidget {
                     mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      (heroImageFile != null)
-                          ? Hero(
-                              tag: heroImageFile!,
-                              child: ScalableImage(
-                                imageFile: heroImageFile!,
-                                height:
-                                    MediaQuery.of(context).size.height * 0.5,
-                              ),
-                            )
-                          : ScalableImage(
-                              imageFile: imageFile,
-                              photoUrl: photoUrl,
-                              height: MediaQuery.of(context).size.height * 0.5,
-                            ),
+                      // (heroImageFile != null)
+                      //     ? Hero(
+                      //         tag: heroImageFile!,
+                      //         child: ScalableImage(
+                      //           imageFile: heroImageFile!,
+                      //           height:
+                      //               MediaQuery.of(context).size.height * 0.5,
+                      //         ),
+                      //       )
+                      //     :
+                      ScalableImage(
+                        photoUrl: photoUrl,
+                        height: MediaQuery.of(context).size.height * 0.5,
+                      ),
                       Text(formattedDate, style: context.textTheme.titleSmall),
                       Text(
                         shopName,

--- a/lib/view/image_detail/card_front.dart
+++ b/lib/view/image_detail/card_front.dart
@@ -51,16 +51,6 @@ class CardFront extends StatelessWidget {
                     mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      // (heroImageFile != null)
-                      //     ? Hero(
-                      //         tag: heroImageFile!,
-                      //         child: ScalableImage(
-                      //           imageFile: heroImageFile!,
-                      //           height:
-                      //               MediaQuery.of(context).size.height * 0.5,
-                      //         ),
-                      //       )
-                      //     :
                       ScalableImage(
                         photoUrl: photoUrl,
                         height: MediaQuery.of(context).size.height * 0.5,

--- a/lib/view/image_detail/image_detail_card.dart
+++ b/lib/view/image_detail/image_detail_card.dart
@@ -40,9 +40,6 @@ class _ImageDetailCardState extends State<ImageDetailCard> {
 
   @override
   Widget build(BuildContext context) {
-    // final heroImageFile =
-    //     (widget.index == widget.heroIndex) ? widget.heroImageFile : null;
-
     return FlipCard(
       fill: Fill.fillBack,
       front: CardFront(

--- a/lib/view/image_detail/image_detail_card.dart
+++ b/lib/view/image_detail/image_detail_card.dart
@@ -16,6 +16,7 @@ class ImageDetailCard extends StatefulWidget {
     required this.shopName,
     required this.dateTime,
     required this.address,
+    required this.photoUrl,
   });
 
   final int index;
@@ -25,6 +26,7 @@ class ImageDetailCard extends StatefulWidget {
   final String shopName;
   final DateTime dateTime;
   final String address;
+  final String photoUrl;
 
   @override
   State<ImageDetailCard> createState() => _ImageDetailCardState();

--- a/lib/view/image_detail/image_detail_card.dart
+++ b/lib/view/image_detail/image_detail_card.dart
@@ -51,7 +51,7 @@ class _ImageDetailCardState extends State<ImageDetailCard> {
       back: CardBack(
         isLinked: true,
         shopName: shopName,
-        imageFileList: [],
+        imageFileList: const [],
         holiday: '土曜',
         address: address,
         url: 'https://example.com',

--- a/lib/view/image_detail/image_detail_card.dart
+++ b/lib/view/image_detail/image_detail_card.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flip_card/flip_card.dart';
 import 'package:flutter/material.dart';
 
@@ -11,8 +9,6 @@ class ImageDetailCard extends StatefulWidget {
     super.key,
     required this.index,
     required this.heroIndex,
-    required this.heroImageFile,
-    required this.imageFile,
     required this.shopName,
     required this.dateTime,
     required this.address,
@@ -21,8 +17,6 @@ class ImageDetailCard extends StatefulWidget {
 
   final int index;
   final int heroIndex;
-  final File heroImageFile;
-  final File imageFile;
   final String shopName;
   final DateTime dateTime;
   final String address;
@@ -33,8 +27,6 @@ class ImageDetailCard extends StatefulWidget {
 }
 
 class _ImageDetailCardState extends State<ImageDetailCard> {
-  File get imageFile => widget.imageFile;
-
   String get shopName => widget.shopName;
 
   DateTime get dateTime => widget.dateTime;
@@ -44,16 +36,17 @@ class _ImageDetailCardState extends State<ImageDetailCard> {
 
   String get address => widget.address;
 
+  String get photoUrl => widget.photoUrl;
+
   @override
   Widget build(BuildContext context) {
-    final heroImageFile =
-        (widget.index == widget.heroIndex) ? widget.heroImageFile : null;
+    // final heroImageFile =
+    //     (widget.index == widget.heroIndex) ? widget.heroImageFile : null;
 
     return FlipCard(
       fill: Fill.fillBack,
       front: CardFront(
-        heroImageFile: heroImageFile,
-        imageFile: imageFile,
+        photoUrl: photoUrl,
         shopName: shopName,
         dateTime: dateTime,
         address: address,
@@ -61,7 +54,7 @@ class _ImageDetailCardState extends State<ImageDetailCard> {
       back: CardBack(
         isLinked: true,
         shopName: shopName,
-        imageFileList: [imageFile, imageFile, imageFile, imageFile],
+        imageFileList: [],
         holiday: '土曜',
         address: address,
         url: 'https://example.com',

--- a/lib/view/image_detail/shop_list_dialog.dart
+++ b/lib/view/image_detail/shop_list_dialog.dart
@@ -117,7 +117,6 @@ Future<void> showShopListDialog(
                                     child: ClipRRect(
                                       borderRadius: BorderRadius.circular(0),
                                       child: ScalableImage(
-                                        imageFile: imageFileList[index],
                                         height: 100,
                                         width: 125,
                                       ),

--- a/lib/view/image_detail/shop_list_dialog.dart
+++ b/lib/view/image_detail/shop_list_dialog.dart
@@ -116,7 +116,7 @@ Future<void> showShopListDialog(
                                     padding: const EdgeInsets.only(left: 10),
                                     child: ClipRRect(
                                       borderRadius: BorderRadius.circular(0),
-                                      child: ScalableImage(
+                                      child: const ScalableImage(
                                         height: 100,
                                         width: 125,
                                       ),

--- a/lib/view/image_detail_page.dart
+++ b/lib/view/image_detail_page.dart
@@ -9,9 +9,12 @@ import 'image_detail/image_detail_card.dart';
 class ImageDetailPage extends StatefulWidget {
   const ImageDetailPage({
     super.key,
+    // TODO(anyone): 不要なタイミングで削除
     required this.heroImageFile,
     required this.photoFileList,
     required this.index,
+    // TODO(anyone): 不要なタイミングで削除
+    required this.photoUrl,
   });
 
   static const String routeName = '/image_detail';
@@ -20,6 +23,7 @@ class ImageDetailPage extends StatefulWidget {
   final File heroImageFile;
   final List<File> photoFileList;
   final int index;
+  final String photoUrl;
 
   @override
   State<ImageDetailPage> createState() => _ImageDetailPageState();
@@ -74,6 +78,7 @@ class _ImageDetailPageState extends State<ImageDetailPage> {
                       index: index,
                       heroIndex: widget.index,
                       heroImageFile: widget.heroImageFile,
+                      photoUrl: widget.photoUrl,
                       imageFile: widget.photoFileList[index],
                       shopName: 'Shop Name $index',
                       dateTime: DateTime.now(),

--- a/lib/view/image_detail_page.dart
+++ b/lib/view/image_detail_page.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 
@@ -10,8 +8,6 @@ class ImageDetailPage extends StatefulWidget {
   const ImageDetailPage({
     super.key,
     // TODO(anyone): 不要なタイミングで削除
-    required this.heroImageFile,
-    required this.photoFileList,
     required this.index,
     // TODO(anyone): 不要なタイミングで削除
     required this.photoUrl,
@@ -20,8 +16,6 @@ class ImageDetailPage extends StatefulWidget {
   static const String routeName = '/image_detail';
   static const String routePath = '/image_detail';
 
-  final File heroImageFile;
-  final List<File> photoFileList;
   final int index;
   final String photoUrl;
 
@@ -65,7 +59,7 @@ class _ImageDetailPageState extends State<ImageDetailPage> {
             Expanded(
               child: PageView.builder(
                 controller: _pageController,
-                itemCount: widget.photoFileList.length,
+                itemCount: 1,
                 itemBuilder: (context, index) {
                   return Padding(
                     padding: EdgeInsets.only(
@@ -77,9 +71,7 @@ class _ImageDetailPageState extends State<ImageDetailPage> {
                     child: ImageDetailCard(
                       index: index,
                       heroIndex: widget.index,
-                      heroImageFile: widget.heroImageFile,
                       photoUrl: widget.photoUrl,
-                      imageFile: widget.photoFileList[index],
                       shopName: 'Shop Name $index',
                       dateTime: DateTime.now(),
                       address: 'Yokohama, kanagawa JAPAN',

--- a/lib/view/root_page.dart
+++ b/lib/view/root_page.dart
@@ -7,6 +7,7 @@ import 'package:go_router/go_router.dart';
 import 'package:package_info/package_info.dart';
 import 'package:url_launcher/url_launcher.dart';
 
+import '../core/database/database.dart';
 import '../core/shared_preferences_service.dart';
 import '../features/auth/auth_repository.dart';
 import 'classify_start_page.dart';
@@ -28,8 +29,10 @@ class RootPage extends ConsumerStatefulWidget {
   ConsumerState<RootPage> createState() => _RootPageState();
 }
 
-class _RootPageState extends ConsumerState<RootPage> {
+class _RootPageState extends ConsumerState<RootPage>
+    with SingleTickerProviderStateMixin {
   bool isLoading = true;
+  late TabController _tabController;
 
   @override
   void initState() {
@@ -41,6 +44,7 @@ class _RootPageState extends ConsumerState<RootPage> {
         }),
       );
     });
+    _tabController = TabController(length: 6, vsync: this);
   }
 
   Future<void> _init() async {
@@ -206,3 +210,88 @@ class _NavigationFrame extends ConsumerWidget {
     }
   }
 }
+
+class CategoryFilterBar extends ConsumerWidget {
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    // final selectedCategory = ref.watch(selectedCategoryProvider).state;
+    final selectedCategory = "";
+
+    return Container(
+      padding: EdgeInsets.symmetric(vertical: 10, horizontal: 20),
+      child: SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            CategoryButton(category: 'すべて', selectedCategory: selectedCategory),
+            CategoryButton(
+                category: 'ラーメン', selectedCategory: selectedCategory),
+            CategoryButton(category: 'カフェ', selectedCategory: selectedCategory),
+            CategoryButton(category: '和食', selectedCategory: selectedCategory),
+            CategoryButton(category: '洋食', selectedCategory: selectedCategory),
+            CategoryButton(
+                category: 'エスニック', selectedCategory: selectedCategory),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class CategoryButton extends ConsumerWidget {
+  final String category;
+  final String selectedCategory;
+
+  const CategoryButton(
+      {required this.category, required this.selectedCategory});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final isSelected = selectedCategory == category;
+
+    return GestureDetector(
+      onTap: () {
+        // ref.read(selectedCategoryProvider).state = category;
+        // ref.read(photoListProvider.notifier).filterByCategory(category);
+      },
+      child: Container(
+        padding: EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+        margin: EdgeInsets.symmetric(horizontal: 4),
+        decoration: BoxDecoration(
+          color: isSelected ? Colors.orange : Colors.grey.shade200,
+          borderRadius: BorderRadius.circular(20),
+        ),
+        child: Text(
+          category,
+          style: TextStyle(
+            color: isSelected ? Colors.white : Colors.black,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+final selectedCategoryProvider = StateProvider<String>((ref) => 'すべて');
+
+class PhotoListNotifier extends StateNotifier<List<Photo>> {
+  PhotoListNotifier() : super([]);
+
+  void filterByCategory(String category) {
+    if (category == 'すべて') {
+      state = allPhotos;
+    } else {
+      state = allPhotos.where((photo) => photo.latitude == category).toList();
+    }
+  }
+
+  List<Photo> get allPhotos => [
+        // 全ての写真データを返すロジック
+      ];
+}
+
+final photoListProvider =
+    StateNotifierProvider<PhotoListNotifier, List<Photo>>((ref) {
+  return PhotoListNotifier();
+});

--- a/lib/view/root_page.dart
+++ b/lib/view/root_page.dart
@@ -251,10 +251,7 @@ class CategoryButton extends ConsumerWidget {
     final isSelected = selectedCategory == category;
 
     return GestureDetector(
-      onTap: () {
-        // ref.read(selectedCategoryProvider).state = category;
-        // ref.read(photoListProvider.notifier).filterByCategory(category);
-      },
+      onTap: () {},
       child: Container(
         padding: EdgeInsets.symmetric(vertical: 8, horizontal: 16),
         margin: EdgeInsets.symmetric(horizontal: 4),
@@ -286,9 +283,7 @@ class PhotoListNotifier extends StateNotifier<List<Photo>> {
     }
   }
 
-  List<Photo> get allPhotos => [
-        // 全ての写真データを返すロジック
-      ];
+  List<Photo> get allPhotos => [];
 }
 
 final photoListProvider =

--- a/lib/view/root_page.dart
+++ b/lib/view/root_page.dart
@@ -7,7 +7,6 @@ import 'package:go_router/go_router.dart';
 import 'package:package_info/package_info.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-import '../core/database/database.dart';
 import '../core/shared_preferences_service.dart';
 import '../features/auth/auth_repository.dart';
 import 'classify_start_page.dart';
@@ -32,7 +31,6 @@ class RootPage extends ConsumerStatefulWidget {
 class _RootPageState extends ConsumerState<RootPage>
     with SingleTickerProviderStateMixin {
   bool isLoading = true;
-  late TabController _tabController;
 
   @override
   void initState() {
@@ -44,7 +42,6 @@ class _RootPageState extends ConsumerState<RootPage>
         }),
       );
     });
-    _tabController = TabController(length: 6, vsync: this);
   }
 
   Future<void> _init() async {
@@ -212,26 +209,32 @@ class _NavigationFrame extends ConsumerWidget {
 }
 
 class CategoryFilterBar extends ConsumerWidget {
+  const CategoryFilterBar({super.key});
+
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     // final selectedCategory = ref.watch(selectedCategoryProvider).state;
-    final selectedCategory = "";
+    const selectedCategory = '';
 
     return Container(
-      padding: EdgeInsets.symmetric(vertical: 10, horizontal: 20),
-      child: SingleChildScrollView(
+      padding: const EdgeInsets.symmetric(vertical: 10, horizontal: 20),
+      child: const SingleChildScrollView(
         scrollDirection: Axis.horizontal,
         child: Row(
           mainAxisAlignment: MainAxisAlignment.spaceBetween,
           children: [
             CategoryButton(category: 'すべて', selectedCategory: selectedCategory),
             CategoryButton(
-                category: 'ラーメン', selectedCategory: selectedCategory),
+              category: 'ラーメン',
+              selectedCategory: selectedCategory,
+            ),
             CategoryButton(category: 'カフェ', selectedCategory: selectedCategory),
             CategoryButton(category: '和食', selectedCategory: selectedCategory),
             CategoryButton(category: '洋食', selectedCategory: selectedCategory),
             CategoryButton(
-                category: 'エスニック', selectedCategory: selectedCategory),
+              category: 'エスニック',
+              selectedCategory: selectedCategory,
+            ),
           ],
         ),
       ),
@@ -240,11 +243,13 @@ class CategoryFilterBar extends ConsumerWidget {
 }
 
 class CategoryButton extends ConsumerWidget {
+  const CategoryButton({
+    super.key,
+    required this.category,
+    required this.selectedCategory,
+  });
   final String category;
   final String selectedCategory;
-
-  const CategoryButton(
-      {required this.category, required this.selectedCategory});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -253,8 +258,8 @@ class CategoryButton extends ConsumerWidget {
     return GestureDetector(
       onTap: () {},
       child: Container(
-        padding: EdgeInsets.symmetric(vertical: 8, horizontal: 16),
-        margin: EdgeInsets.symmetric(horizontal: 4),
+        padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+        margin: const EdgeInsets.symmetric(horizontal: 4),
         decoration: BoxDecoration(
           color: isSelected ? Colors.orange : Colors.grey.shade200,
           borderRadius: BorderRadius.circular(20),
@@ -269,24 +274,3 @@ class CategoryButton extends ConsumerWidget {
     );
   }
 }
-
-final selectedCategoryProvider = StateProvider<String>((ref) => 'すべて');
-
-class PhotoListNotifier extends StateNotifier<List<Photo>> {
-  PhotoListNotifier() : super([]);
-
-  void filterByCategory(String category) {
-    if (category == 'すべて') {
-      state = allPhotos;
-    } else {
-      state = allPhotos.where((photo) => photo.latitude == category).toList();
-    }
-  }
-
-  List<Photo> get allPhotos => [];
-}
-
-final photoListProvider =
-    StateNotifierProvider<PhotoListNotifier, List<Photo>>((ref) {
-  return PhotoListNotifier();
-});

--- a/lib/view/widgets/scalable_image.dart
+++ b/lib/view/widgets/scalable_image.dart
@@ -1,18 +1,37 @@
 import 'dart:io';
 
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 
+// TODO(anyone): 全体的にImageをphotoの名称に変更
 class ScalableImage extends StatefulWidget {
   const ScalableImage({
-    required this.imageFile,
+    // TODO(anyone): 不要になったタイミングで削除
+    this.imageFile,
+    this.photoUrl,
     this.height,
     this.width,
     super.key,
-  });
+  }) : assert(imageFile != null || photoUrl != null);
 
-  final File imageFile;
+  final File? imageFile;
   final double? height;
   final double? width;
+  final String? photoUrl;
+
+  // TODO(anyone): このメソッドは不要になったタイミングで削除
+  Widget get photoWidget {
+    if (imageFile != null) {
+      return Image.file(
+        imageFile!,
+        fit: BoxFit.cover,
+      );
+    }
+    return CachedNetworkImage(
+      imageUrl: photoUrl!,
+      fit: BoxFit.cover,
+    );
+  }
 
   @override
   State<ScalableImage> createState() => ScalableImageState();
@@ -41,10 +60,7 @@ class ScalableImageState extends State<ScalableImage> {
           child: SizedBox(
             height: widget.height,
             width: widget.width,
-            child: Image.file(
-              widget.imageFile,
-              fit: BoxFit.cover,
-            ),
+            child: widget.photoWidget,
           ),
         ),
         Positioned(
@@ -58,10 +74,7 @@ class ScalableImageState extends State<ScalableImage> {
             ),
             onPressed: () {
               showImageDialog(
-                Image.file(
-                  widget.imageFile,
-                  fit: BoxFit.cover,
-                ),
+                widget.photoWidget,
               );
             },
           ),

--- a/lib/view/widgets/scalable_image.dart
+++ b/lib/view/widgets/scalable_image.dart
@@ -1,5 +1,3 @@
-import 'dart:io';
-
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 
@@ -7,26 +5,18 @@ import 'package:flutter/material.dart';
 class ScalableImage extends StatefulWidget {
   const ScalableImage({
     // TODO(anyone): 不要になったタイミングで削除
-    this.imageFile,
     this.photoUrl,
     this.height,
     this.width,
     super.key,
-  }) : assert(imageFile != null || photoUrl != null);
+  }) : assert(photoUrl != null);
 
-  final File? imageFile;
   final double? height;
   final double? width;
   final String? photoUrl;
 
   // TODO(anyone): このメソッドは不要になったタイミングで削除
   Widget get photoWidget {
-    if (imageFile != null) {
-      return Image.file(
-        imageFile!,
-        fit: BoxFit.cover,
-      );
-    }
     return CachedNetworkImage(
       imageUrl: photoUrl!,
       fit: BoxFit.cover,

--- a/lib/view/widgets/scalable_image.dart
+++ b/lib/view/widgets/scalable_image.dart
@@ -9,7 +9,7 @@ class ScalableImage extends StatefulWidget {
     this.height,
     this.width,
     super.key,
-  }) : assert(photoUrl != null);
+  });
 
   final double? height;
   final double? width;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -145,6 +145,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.9.2"
+  cached_network_image:
+    dependency: "direct main"
+    description:
+      name: cached_network_image
+      sha256: "4a5d8d2c728b0f3d0245f69f921d7be90cae4c2fd5288f773088672c0893f819"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.0"
+  cached_network_image_platform_interface:
+    dependency: transitive
+    description:
+      name: cached_network_image_platform_interface
+      sha256: ff0c949e323d2a1b52be73acce5b4a7b04063e61414c8ca542dbba47281630a7
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
+  cached_network_image_web:
+    dependency: transitive
+    description:
+      name: cached_network_image_web
+      sha256: "6322dde7a5ad92202e64df659241104a43db20ed594c41ca18de1014598d7996"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
   change_app_package_name:
     dependency: "direct dev"
     description:
@@ -558,6 +582,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_cache_manager:
+    dependency: transitive
+    description:
+      name: flutter_cache_manager
+      sha256: a77f77806a790eb9ba0118a5a3a936e81c4fea2b61533033b2b0c3d50bbde5ea
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.0"
   flutter_dotenv:
     dependency: "direct main"
     description:
@@ -904,6 +936,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  octo_image:
+    dependency: transitive
+    description:
+      name: octo_image
+      sha256: "34faa6639a78c7e3cbe79be6f9f96535867e879748ade7d17c9b1ae7536293bd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   package_config:
     dependency: transitive
     description:
@@ -1205,6 +1245,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.0"
+  sqflite:
+    dependency: transitive
+    description:
+      name: sqflite
+      sha256: a43e5a27235518c03ca238e7b4732cf35eabe863a369ceba6cbefa537a66f16d
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.3+1"
+  sqflite_common:
+    dependency: transitive
+    description:
+      name: sqflite_common
+      sha256: "3da423ce7baf868be70e2c0976c28a1bb2f73644268b7ffa7d2e08eab71f16a4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.4"
   sqlite3:
     dependency: transitive
     description:
@@ -1269,6 +1325,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
+  synchronized:
+    dependency: transitive
+    description:
+      name: synchronized
+      sha256: "539ef412b170d65ecdafd780f924e5be3f60032a1128df156adad6c5b373d558"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0+1"
   term_glyph:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,6 +10,7 @@ environment:
 
 dependencies:
   appinio_swiper: ^2.1.1
+  cached_network_image: ^3.4.0
   cloud_firestore: any
   cloud_functions: any
   collection: ^1.17.2


### PR DESCRIPTION
## 関連のタスク issue
<!-- Notionリンクを記載  -->
https://www.notion.so/masakisato/firestore-UI-ba7925b569bd41b59eba84bc7d961c60?pvs=4

## 対応したこと
<!-- 実装の概要を箇条書きする  -->
-  ローカルではなくgcsの画像を表示するように修正
-  カテゴリタブから切り替えられるように実装

## 未解決事項
<!-- 別PRで対応するような状況があれば記載  -->  
- 元々あった裏面のお店の画像表示用のimageFileListを削除したので、それを復活させる
-  合わせてimageFileListではわかりづらいので、shopImageFileListなどに修正する。

## 実際の挙動
<!-- UIに関わるようであればスクリーンショット、動きのあるものは動画 or GIF  -->  
<!-- 入力エリアにドラッグ&ドロップしてアップロード  -->
サイズの関係で、notionに添付しました。
https://www.notion.so/masakisato/firestore-UI-ba7925b569bd41b59eba84bc7d961c60?pvs=4

## チェックリスト
<!-- 空白を消して`x`をつける  -->  
- [x] 実装完了後、問題が起こっていないか実際に動作確認したか  
- [x] 補足があった方が良い/重点的にレビューが欲しい箇所にGitHub上でコメントをしたか

## その他コメント

<!-- 何かあれば！  -->
