### PR TITLE
［TAS-183］ギャラリー詳細画面でfirestore情報を表示する

### DIFF
--- a/lib/features/store/store.dart
+++ b/lib/features/store/store.dart
@@ -36,8 +36,8 @@ class Store with _$Store {
     /// FirebaseStorageの（ストアの）住所
     @Default('') String address,
 
-    /// FirebaseStorageの（ストアの）休日
-    @Default('') String holiday,
+    /// FirebaseStorageの（ストアの）営業時間
+    @Default(<String, String>{}) Map<String, String> openingHours,
 
     /// 写真の撮影日時
     @timestampConverter

--- a/lib/features/store/store.freezed.dart
+++ b/lib/features/store/store.freezed.dart
@@ -46,8 +46,8 @@ mixin _$Store {
   /// FirebaseStorageの（ストアの）住所
   String get address => throw _privateConstructorUsedError;
 
-  /// FirebaseStorageの（ストアの）休日
-  String get holiday => throw _privateConstructorUsedError;
+  /// FirebaseStorageの（ストアの）営業時間
+  Map<String, String> get openingHours => throw _privateConstructorUsedError;
 
   /// 写真の撮影日時
   @timestampConverter
@@ -73,7 +73,7 @@ abstract class $StoreCopyWith<$Res> {
       String phoneNumber,
       String website,
       String address,
-      String holiday,
+      Map<String, String> openingHours,
       @timestampConverter UnionTimestamp shotAt,
       String storeId});
 
@@ -103,7 +103,7 @@ class _$StoreCopyWithImpl<$Res, $Val extends Store>
     Object? phoneNumber = null,
     Object? website = null,
     Object? address = null,
-    Object? holiday = null,
+    Object? openingHours = null,
     Object? shotAt = null,
     Object? storeId = null,
   }) {
@@ -140,10 +140,10 @@ class _$StoreCopyWithImpl<$Res, $Val extends Store>
           ? _value.address
           : address // ignore: cast_nullable_to_non_nullable
               as String,
-      holiday: null == holiday
-          ? _value.holiday
-          : holiday // ignore: cast_nullable_to_non_nullable
-              as String,
+      openingHours: null == openingHours
+          ? _value.openingHours
+          : openingHours // ignore: cast_nullable_to_non_nullable
+              as Map<String, String>,
       shotAt: null == shotAt
           ? _value.shotAt
           : shotAt // ignore: cast_nullable_to_non_nullable
@@ -196,7 +196,7 @@ abstract class _$$StoreImplCopyWith<$Res> implements $StoreCopyWith<$Res> {
       String phoneNumber,
       String website,
       String address,
-      String holiday,
+      Map<String, String> openingHours,
       @timestampConverter UnionTimestamp shotAt,
       String storeId});
 
@@ -227,7 +227,7 @@ class __$$StoreImplCopyWithImpl<$Res>
     Object? phoneNumber = null,
     Object? website = null,
     Object? address = null,
-    Object? holiday = null,
+    Object? openingHours = null,
     Object? shotAt = null,
     Object? storeId = null,
   }) {
@@ -264,10 +264,10 @@ class __$$StoreImplCopyWithImpl<$Res>
           ? _value.address
           : address // ignore: cast_nullable_to_non_nullable
               as String,
-      holiday: null == holiday
-          ? _value.holiday
-          : holiday // ignore: cast_nullable_to_non_nullable
-              as String,
+      openingHours: null == openingHours
+          ? _value._openingHours
+          : openingHours // ignore: cast_nullable_to_non_nullable
+              as Map<String, String>,
       shotAt: null == shotAt
           ? _value.shotAt
           : shotAt // ignore: cast_nullable_to_non_nullable
@@ -294,10 +294,11 @@ class _$StoreImpl extends _Store {
       this.phoneNumber = '',
       this.website = '',
       this.address = '',
-      this.holiday = '',
+      final Map<String, String> openingHours = const <String, String>{},
       @timestampConverter this.shotAt = const UnionTimestamp.serverTimestamp(),
       this.storeId = ''})
       : _imageUrls = imageUrls,
+        _openingHours = openingHours,
         super._();
 
   factory _$StoreImpl.fromJson(Map<String, dynamic> json) =>
@@ -352,10 +353,17 @@ class _$StoreImpl extends _Store {
   @JsonKey()
   final String address;
 
-  /// FirebaseStorageの（ストアの）休日
+  /// FirebaseStorageの（ストアの）営業時間
+  final Map<String, String> _openingHours;
+
+  /// FirebaseStorageの（ストアの）営業時間
   @override
   @JsonKey()
-  final String holiday;
+  Map<String, String> get openingHours {
+    if (_openingHours is EqualUnmodifiableMapView) return _openingHours;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableMapView(_openingHours);
+  }
 
   /// 写真の撮影日時
   @override
@@ -368,7 +376,7 @@ class _$StoreImpl extends _Store {
 
   @override
   String toString() {
-    return 'Store(id: $id, createdAt: $createdAt, updatedAt: $updatedAt, imageUrls: $imageUrls, name: $name, phoneNumber: $phoneNumber, website: $website, address: $address, holiday: $holiday, shotAt: $shotAt, storeId: $storeId)';
+    return 'Store(id: $id, createdAt: $createdAt, updatedAt: $updatedAt, imageUrls: $imageUrls, name: $name, phoneNumber: $phoneNumber, website: $website, address: $address, openingHours: $openingHours, shotAt: $shotAt, storeId: $storeId)';
   }
 
   @override
@@ -388,7 +396,8 @@ class _$StoreImpl extends _Store {
                 other.phoneNumber == phoneNumber) &&
             (identical(other.website, website) || other.website == website) &&
             (identical(other.address, address) || other.address == address) &&
-            (identical(other.holiday, holiday) || other.holiday == holiday) &&
+            const DeepCollectionEquality()
+                .equals(other._openingHours, _openingHours) &&
             (identical(other.shotAt, shotAt) || other.shotAt == shotAt) &&
             (identical(other.storeId, storeId) || other.storeId == storeId));
   }
@@ -405,7 +414,7 @@ class _$StoreImpl extends _Store {
       phoneNumber,
       website,
       address,
-      holiday,
+      const DeepCollectionEquality().hash(_openingHours),
       shotAt,
       storeId);
 
@@ -433,7 +442,7 @@ abstract class _Store extends Store {
       final String phoneNumber,
       final String website,
       final String address,
-      final String holiday,
+      final Map<String, String> openingHours,
       @timestampConverter final UnionTimestamp shotAt,
       final String storeId}) = _$StoreImpl;
   const _Store._() : super._();
@@ -476,8 +485,8 @@ abstract class _Store extends Store {
   String get address;
   @override
 
-  /// FirebaseStorageの（ストアの）休日
-  String get holiday;
+  /// FirebaseStorageの（ストアの）営業時間
+  Map<String, String> get openingHours;
   @override
 
   /// 写真の撮影日時

--- a/lib/features/store/store.g.dart
+++ b/lib/features/store/store.g.dart
@@ -22,7 +22,10 @@ _$StoreImpl _$$StoreImplFromJson(Map<String, dynamic> json) => _$StoreImpl(
       phoneNumber: json['phoneNumber'] as String? ?? '',
       website: json['website'] as String? ?? '',
       address: json['address'] as String? ?? '',
-      holiday: json['holiday'] as String? ?? '',
+      openingHours: (json['openingHours'] as Map<String, dynamic>?)?.map(
+            (k, e) => MapEntry(k, e as String),
+          ) ??
+          const <String, String>{},
       shotAt: json['shotAt'] == null
           ? const UnionTimestamp.serverTimestamp()
           : timestampConverter.fromJson(json['shotAt'] as Object),
@@ -39,7 +42,7 @@ Map<String, dynamic> _$$StoreImplToJson(_$StoreImpl instance) =>
       'phoneNumber': instance.phoneNumber,
       'website': instance.website,
       'address': instance.address,
-      'holiday': instance.holiday,
+      'openingHours': instance.openingHours,
       'shotAt': timestampConverter.toJson(instance.shotAt),
       'storeId': instance.storeId,
     };

--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -56,7 +56,7 @@ class _HomePageState extends ConsumerState<HomePage>
     });
   }
 
-  List<Map<String, String>>? photoUrls; // Firebaseからダウンロードした写真のURLとカテゴリを保持
+  List<Photo>? photoUrls; // Firebaseからダウンロードした写真のURLとカテゴリを保持
 
   Future<void> _downloadPhotos(WidgetRef ref) async {
     debugPrint('_downloadPhotos start!!!');
@@ -72,11 +72,7 @@ class _HomePageState extends ConsumerState<HomePage>
         );
 
     setState(() {
-      photoUrls = result
-          .map((e) =>
-              {'url': e.url, 'category': e.category, 'storeId': e.storeId},)
-          .where((e) => e['url']!.isNotEmpty)
-          .toList();
+      photoUrls = result.where((e) => e.url.isNotEmpty).toList();
       debugPrint('photoUrls: $photoUrls');
       debugPrint('result: $result');
     });
@@ -136,12 +132,12 @@ class _HomePageState extends ConsumerState<HomePage>
       return const Center(child: CircularProgressIndicator());
     }
 
-    List<Map<String, String>> filteredPhotos;
+    List<Photo> filteredPhotos;
     if (category == 'すべて') {
       filteredPhotos = photoUrls!;
     } else {
       filteredPhotos =
-          photoUrls!.where((photo) => photo['category'] == category).toList();
+          photoUrls!.where((photo) => photo.category == category).toList();
     }
 
     return Padding(
@@ -151,12 +147,7 @@ class _HomePageState extends ConsumerState<HomePage>
         mainAxisSpacing: 8,
         crossAxisSpacing: 8,
         itemBuilder: (context, index) {
-          final photoMap = filteredPhotos[index];
-          final photo = Photo(
-            url: photoMap['url']!,
-            category: photoMap['category']!,
-            storeId: photoMap['storeId']!,
-          );
+          final photo = filteredPhotos[index];
 
           return Hero(
             tag: photo,

--- a/lib/view/image_detail/card_back.dart
+++ b/lib/view/image_detail/card_back.dart
@@ -63,9 +63,14 @@ class CardBack extends StatelessWidget {
 
     final Map<String, String> sortedOpeningHours;
     if (storeOpeningHours != null) {
-      sortedOpeningHours = Map.fromEntries(storeOpeningHours!.entries.toList()
-        ..sort((a, b) =>
-            orderedKeys.indexOf(a.key).compareTo(orderedKeys.indexOf(b.key)),),);
+      sortedOpeningHours = Map.fromEntries(
+        storeOpeningHours!.entries.toList()
+          ..sort(
+            (a, b) => orderedKeys
+                .indexOf(a.key)
+                .compareTo(orderedKeys.indexOf(b.key)),
+          ),
+      );
     } else {
       sortedOpeningHours = {};
     }
@@ -204,7 +209,8 @@ class CardBack extends StatelessWidget {
                                     ),
                                   ] else ...[
                                     const Padding(
-                                        padding: EdgeInsets.only(left: 32),),
+                                      padding: EdgeInsets.only(left: 32),
+                                    ),
                                   ],
                                   Text(
                                     _getWeekday(entry.key),

--- a/lib/view/image_detail/card_back.dart
+++ b/lib/view/image_detail/card_back.dart
@@ -65,7 +65,7 @@ class CardBack extends StatelessWidget {
     if (storeOpeningHours != null) {
       sortedOpeningHours = Map.fromEntries(storeOpeningHours!.entries.toList()
         ..sort((a, b) =>
-            orderedKeys.indexOf(a.key).compareTo(orderedKeys.indexOf(b.key)),),);
+            orderedKeys.indexOf(a.key).compareTo(orderedKeys.indexOf(b.key))));
     } else {
       sortedOpeningHours = {};
     }
@@ -189,7 +189,7 @@ class CardBack extends StatelessWidget {
                         children: [
                           ...sortedOpeningHours.entries.map((entry) {
                             // アイコンを最初の要素にのみ表示
-                            final isFirst =
+                            final bool isFirst =
                                 sortedOpeningHours.entries.first.key ==
                                     entry.key;
                             return Padding(
@@ -204,7 +204,7 @@ class CardBack extends StatelessWidget {
                                     ),
                                   ] else ...[
                                     const Padding(
-                                        padding: EdgeInsets.only(left: 32),),
+                                        padding: EdgeInsets.only(left: 32)),
                                   ],
                                   Text(
                                     _getWeekday(entry.key),
@@ -222,7 +222,7 @@ class CardBack extends StatelessWidget {
                                 ],
                               ),
                             );
-                          }),
+                          })
                         ],
                       ),
                     ),

--- a/lib/view/image_detail/card_back.dart
+++ b/lib/view/image_detail/card_back.dart
@@ -65,7 +65,7 @@ class CardBack extends StatelessWidget {
     if (storeOpeningHours != null) {
       sortedOpeningHours = Map.fromEntries(storeOpeningHours!.entries.toList()
         ..sort((a, b) =>
-            orderedKeys.indexOf(a.key).compareTo(orderedKeys.indexOf(b.key))));
+            orderedKeys.indexOf(a.key).compareTo(orderedKeys.indexOf(b.key)),),);
     } else {
       sortedOpeningHours = {};
     }
@@ -189,7 +189,7 @@ class CardBack extends StatelessWidget {
                         children: [
                           ...sortedOpeningHours.entries.map((entry) {
                             // アイコンを最初の要素にのみ表示
-                            final bool isFirst =
+                            final isFirst =
                                 sortedOpeningHours.entries.first.key ==
                                     entry.key;
                             return Padding(
@@ -204,7 +204,7 @@ class CardBack extends StatelessWidget {
                                     ),
                                   ] else ...[
                                     const Padding(
-                                        padding: EdgeInsets.only(left: 32)),
+                                        padding: EdgeInsets.only(left: 32),),
                                   ],
                                   Text(
                                     _getWeekday(entry.key),
@@ -222,7 +222,7 @@ class CardBack extends StatelessWidget {
                                 ],
                               ),
                             );
-                          })
+                          }),
                         ],
                       ),
                     ),

--- a/lib/view/image_detail/card_back.dart
+++ b/lib/view/image_detail/card_back.dart
@@ -14,6 +14,7 @@ class CardBack extends StatelessWidget {
     this.holiday,
     this.address,
     this.storeUrl,
+    this.storeOpeningHours,
     super.key,
   });
 
@@ -24,6 +25,7 @@ class CardBack extends StatelessWidget {
   final String? holiday;
   final String? address;
   final String? storeUrl;
+  final Map<String, String>? storeOpeningHours;
 
   @override
   Widget build(BuildContext context) {
@@ -47,6 +49,25 @@ class CardBack extends StatelessWidget {
           ),
         ),
       );
+    }
+
+    final orderedKeys = [
+      'sunday_hours',
+      'monday_hours',
+      'tuesday_hours',
+      'wednesday_hours',
+      'thursday_hours',
+      'friday_hours',
+      'saturday_hours',
+    ];
+
+    final Map<String, String> sortedOpeningHours;
+    if (storeOpeningHours != null) {
+      sortedOpeningHours = Map.fromEntries(storeOpeningHours!.entries.toList()
+        ..sort((a, b) =>
+            orderedKeys.indexOf(a.key).compareTo(orderedKeys.indexOf(b.key))));
+    } else {
+      sortedOpeningHours = {};
     }
 
     return Card(
@@ -124,25 +145,6 @@ class CardBack extends StatelessWidget {
                   padding: EdgeInsets.symmetric(vertical: 16),
                   child: Divider(),
                 ),
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-                  children: [
-                    if (openTime != null)
-                      Text(
-                        openTime!,
-                        style: Theme.of(context).textTheme.bodySmall,
-                      ),
-                    if (holiday != null)
-                      Text(
-                        '$holiday定休',
-                        style: Theme.of(context).textTheme.bodySmall,
-                      ),
-                  ],
-                ),
-                const Padding(
-                  padding: EdgeInsets.symmetric(vertical: 16),
-                  child: Divider(),
-                ),
                 if (address != null)
                   Row(
                     mainAxisSize: MainAxisSize.min,
@@ -176,9 +178,55 @@ class CardBack extends StatelessWidget {
                     ],
                   ),
                 const Padding(
-                  padding: EdgeInsets.symmetric(vertical: 8),
+                  padding: EdgeInsets.symmetric(vertical: 18),
                   child: Divider(),
                 ),
+                if (storeOpeningHours != null)
+                  Expanded(
+                    child: SingleChildScrollView(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          ...sortedOpeningHours.entries.map((entry) {
+                            // アイコンを最初の要素にのみ表示
+                            final bool isFirst =
+                                sortedOpeningHours.entries.first.key ==
+                                    entry.key;
+                            return Padding(
+                              padding: const EdgeInsets.symmetric(vertical: 2),
+                              child: Row(
+                                children: [
+                                  if (isFirst) ...[
+                                    const Padding(
+                                      padding:
+                                          EdgeInsets.only(left: 8, right: 8),
+                                      child: Icon(Icons.access_time, size: 16),
+                                    ),
+                                  ] else ...[
+                                    const Padding(
+                                        padding: EdgeInsets.only(left: 32)),
+                                  ],
+                                  Text(
+                                    _getWeekday(entry.key),
+                                    style:
+                                        Theme.of(context).textTheme.bodyMedium,
+                                  ),
+                                  const SizedBox(width: 4),
+                                  Text(
+                                    entry.value.toLowerCase() == 'closed'
+                                        ? '定休日'
+                                        : entry.value,
+                                    style:
+                                        Theme.of(context).textTheme.bodyMedium,
+                                  ),
+                                ],
+                              ),
+                            );
+                          })
+                        ],
+                      ),
+                    ),
+                  ),
                 const SizedBox(height: 32),
               ],
             ),
@@ -237,5 +285,26 @@ class CardBack extends StatelessWidget {
         ],
       ),
     );
+  }
+
+  String _getWeekday(String key) {
+    switch (key) {
+      case 'monday_hours':
+        return '月:';
+      case 'tuesday_hours':
+        return '火:';
+      case 'wednesday_hours':
+        return '水:';
+      case 'thursday_hours':
+        return '木:';
+      case 'friday_hours':
+        return '金:';
+      case 'saturday_hours':
+        return '土:';
+      case 'sunday_hours':
+        return '日:';
+      default:
+        return key;
+    }
   }
 }

--- a/lib/view/image_detail/card_front.dart
+++ b/lib/view/image_detail/card_front.dart
@@ -25,8 +25,6 @@ class CardFront extends StatelessWidget {
   Widget build(BuildContext context) {
     final formattedDate = '${dateTime.year}/${dateTime.month}/${dateTime.day}';
 
-    print('showCardBack: $showCardBack');
-
     return Card(
       color: Colors.white,
       elevation: 5,
@@ -66,21 +64,22 @@ class CardFront extends StatelessWidget {
                         overflow: TextOverflow.ellipsis,
                         style: context.textTheme.titleMedium,
                       ),
-                      const Divider(),
-                      Row(
-                        mainAxisSize: MainAxisSize.min,
-                        children: [
-                          const Icon(Icons.pin_drop_outlined, size: 18),
-                          const Gap(4),
-                          Expanded(
-                            child: Text(
-                              address,
-                              style: context.textTheme.bodySmall,
-                              softWrap: true,
+                      if (showCardBack) const Divider(),
+                      if (showCardBack)
+                        Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            const Icon(Icons.pin_drop_outlined, size: 18),
+                            const Gap(4),
+                            Expanded(
+                              child: Text(
+                                address,
+                                style: context.textTheme.bodySmall,
+                                softWrap: true,
+                              ),
                             ),
-                          ),
-                        ],
-                      ),
+                          ],
+                        ),
                     ],
                   ),
                 ),

--- a/lib/view/image_detail/card_front.dart
+++ b/lib/view/image_detail/card_front.dart
@@ -12,16 +12,20 @@ class CardFront extends StatelessWidget {
     required this.storeName,
     required this.dateTime,
     required this.address,
+    required this.showCardBack,
   });
 
   final String photoUrl;
   final String storeName;
   final DateTime dateTime;
   final String address;
+  final bool showCardBack;
 
   @override
   Widget build(BuildContext context) {
     final formattedDate = '${dateTime.year}/${dateTime.month}/${dateTime.day}';
+
+    print('showCardBack: $showCardBack');
 
     return Card(
       color: Colors.white,
@@ -83,18 +87,19 @@ class CardFront extends StatelessWidget {
               ],
             ),
           ),
-          Container(
-            height: 36,
-            width: 36,
-            decoration: BoxDecoration(
-              borderRadius: const BorderRadius.only(
-                topRight: Radius.circular(8),
+          if (showCardBack)
+            Container(
+              height: 36,
+              width: 36,
+              decoration: BoxDecoration(
+                borderRadius: const BorderRadius.only(
+                  topRight: Radius.circular(8),
+                ),
+                border: Border.all(),
+                color: Themes.gray[100],
               ),
-              border: Border.all(),
-              color: Themes.gray[100],
+              child: const Icon(Icons.refresh),
             ),
-            child: const Icon(Icons.refresh),
-          ),
         ],
       ),
     );

--- a/lib/view/image_detail/image_detail_card.dart
+++ b/lib/view/image_detail/image_detail_card.dart
@@ -5,60 +5,74 @@ import 'card_back.dart';
 import 'card_front.dart';
 
 class ImageDetailCard extends StatefulWidget {
-  const ImageDetailCard(
-      {super.key,
-      required this.storeName,
-      required this.dateTime,
-      required this.address,
-      required this.photoUrl,
-      required this.storeUrl,
-      required this.storeImageUrls,});
+  const ImageDetailCard({
+    super.key,
+    this.storeName = '',
+    required this.dateTime,
+    this.address = '',
+    this.photoUrl = '',
+    this.storeUrl = '',
+    this.storeImageUrls = const [],
+    this.showCardBack = true,
+  });
 
-  final String storeName;
+  final String? storeName;
   final DateTime dateTime;
-  final String address;
+  final String? address;
   final String photoUrl;
-  final String storeUrl;
-  final List<String> storeImageUrls;
+  final String? storeUrl;
+  final List<String>? storeImageUrls;
+  final bool showCardBack;
 
   @override
   State<ImageDetailCard> createState() => _ImageDetailCardState();
 }
 
 class _ImageDetailCardState extends State<ImageDetailCard> {
-  String get storeName => widget.storeName;
+  String get storeName => widget.storeName ?? '';
 
   DateTime get dateTime => widget.dateTime;
 
   String get formattedDate =>
       '${dateTime.year}/${dateTime.month}/${dateTime.day}';
 
-  String get address => widget.address;
+  String get address => widget.address ?? '';
 
   String get photoUrl => widget.photoUrl;
 
-  String get storeUrl => widget.storeUrl;
+  String get storeUrl => widget.storeUrl ?? '';
 
-  List<String> get storeImageUrls => widget.storeImageUrls;
+  List<String> get storeImageUrls => widget.storeImageUrls ?? [];
+
+  bool get showCardBack => widget.showCardBack;
 
   @override
   Widget build(BuildContext context) {
-    return FlipCard(
-      fill: Fill.fillBack,
-      front: CardFront(
-        photoUrl: photoUrl,
-        storeName: storeName,
-        dateTime: dateTime,
-        address: address,
-      ),
-      back: CardBack(
-        isLinked: true,
-        storeName: storeName,
-        storeImageUrls: storeImageUrls,
-        holiday: '土曜',
-        address: address,
-        storeUrl: storeUrl,
-      ),
-    );
+    return showCardBack
+        ? FlipCard(
+            fill: Fill.fillBack,
+            front: CardFront(
+              photoUrl: photoUrl,
+              storeName: storeName,
+              dateTime: dateTime,
+              address: address,
+              showCardBack: showCardBack,
+            ),
+            back: CardBack(
+              isLinked: true,
+              storeName: storeName,
+              storeImageUrls: storeImageUrls,
+              holiday: '土曜',
+              address: address,
+              storeUrl: storeUrl,
+            ),
+          )
+        : CardFront(
+            photoUrl: photoUrl,
+            storeName: storeName,
+            dateTime: dateTime,
+            address: address,
+            showCardBack: showCardBack,
+          );
   }
 }

--- a/lib/view/image_detail/image_detail_card.dart
+++ b/lib/view/image_detail/image_detail_card.dart
@@ -14,6 +14,7 @@ class ImageDetailCard extends StatefulWidget {
     this.storeUrl = '',
     this.storeImageUrls = const [],
     this.showCardBack = true,
+    required this.storeOpeningHours,
   });
 
   final String? storeName;
@@ -23,6 +24,7 @@ class ImageDetailCard extends StatefulWidget {
   final String? storeUrl;
   final List<String>? storeImageUrls;
   final bool showCardBack;
+  final Map<String, String>? storeOpeningHours;
 
   @override
   State<ImageDetailCard> createState() => _ImageDetailCardState();
@@ -43,6 +45,8 @@ class _ImageDetailCardState extends State<ImageDetailCard> {
   String get storeUrl => widget.storeUrl ?? '';
 
   List<String> get storeImageUrls => widget.storeImageUrls ?? [];
+
+  Map<String, String> get storeOpeningHours => widget.storeOpeningHours ?? {};
 
   bool get showCardBack => widget.showCardBack;
 
@@ -65,6 +69,7 @@ class _ImageDetailCardState extends State<ImageDetailCard> {
               holiday: '土曜',
               address: address,
               storeUrl: storeUrl,
+              storeOpeningHours: storeOpeningHours,
             ),
           )
         : CardFront(

--- a/lib/view/image_detail_page.dart
+++ b/lib/view/image_detail_page.dart
@@ -61,7 +61,9 @@ class _ImageDetailPageState extends ConsumerState<ImageDetailPage> {
     }
     final postalCodeIndex = fullAddress.indexOf('〒');
     final postalCode = fullAddress.substring(
-        postalCodeIndex, fullAddress.indexOf(' ', postalCodeIndex),);
+      postalCodeIndex,
+      fullAddress.indexOf(' ', postalCodeIndex),
+    );
     final address =
         fullAddress.substring(fullAddress.indexOf(' ', postalCodeIndex) + 1);
     return '$postalCode\n$address';
@@ -113,6 +115,7 @@ class _ImageDetailPageState extends ConsumerState<ImageDetailPage> {
                           dateTime: DateTime.now(),
                           address: formatAddress(store?.address),
                           storeUrl: store?.website,
+                          storeOpeningHours: store?.openingHours,
                           storeImageUrls: store?.imageUrls,
                           showCardBack: widget.photo.storeId.isNotEmpty,
                         ),

--- a/lib/view/image_detail_page.dart
+++ b/lib/view/image_detail_page.dart
@@ -59,12 +59,12 @@ class _ImageDetailPageState extends ConsumerState<ImageDetailPage> {
     if (fullAddress == null || fullAddress.isEmpty) {
       return null;
     }
-    final int postalCodeIndex = fullAddress.indexOf('〒');
-    final String postalCode = fullAddress.substring(
-        postalCodeIndex, fullAddress.indexOf(' ', postalCodeIndex));
-    final String address =
+    final postalCodeIndex = fullAddress.indexOf('〒');
+    final postalCode = fullAddress.substring(
+        postalCodeIndex, fullAddress.indexOf(' ', postalCodeIndex),);
+    final address =
         fullAddress.substring(fullAddress.indexOf(' ', postalCodeIndex) + 1);
-    return postalCode + '\n' + address;
+    return '$postalCode\n$address';
   }
 
   @override
@@ -94,13 +94,7 @@ class _ImageDetailPageState extends ConsumerState<ImageDetailPage> {
                   return const Center(child: CircularProgressIndicator());
                 } else if (snapshot.hasError) {
                   return Center(child: Text('Error: ${snapshot.error}'));
-                }
-                // else if (!snapshot.hasData || snapshot.data == null) {
-                //   return const Center(
-                //     child: Text('No store information available'),
-                //   );
-                // }
-                else {
+                } else {
                   final store = snapshot.data;
                   return PageView.builder(
                     controller: _pageController,

--- a/lib/view/image_detail_page.dart
+++ b/lib/view/image_detail_page.dart
@@ -55,6 +55,15 @@ class _ImageDetailPageState extends ConsumerState<ImageDetailPage> {
     );
   }
 
+  String formatAddress(String fullAddress) {
+    final int postalCodeIndex = fullAddress.indexOf('〒');
+    final String postalCode = fullAddress.substring(
+        postalCodeIndex, fullAddress.indexOf(' ', postalCodeIndex));
+    final String address =
+        fullAddress.substring(fullAddress.indexOf(' ', postalCodeIndex) + 1);
+    return postalCode + '\n' + address;
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -100,12 +109,13 @@ class _ImageDetailPageState extends ConsumerState<ImageDetailPage> {
                           right: 4,
                         ),
                         child: ImageDetailCard(
-                            photoUrl: widget.photo.url,
-                            storeName: store.name,
-                            dateTime: DateTime.now(),
-                            address: store.address,
-                            storeUrl: store.website,
-                            storeImageUrls: store.imageUrls,),
+                          photoUrl: widget.photo.url,
+                          storeName: store.name,
+                          dateTime: DateTime.now(),
+                          address: formatAddress(store.address),
+                          storeUrl: store.website,
+                          storeImageUrls: store.imageUrls,
+                        ),
                       );
                     },
                   );

--- a/lib/view/image_detail_page.dart
+++ b/lib/view/image_detail_page.dart
@@ -46,7 +46,7 @@ class _ImageDetailPageState extends ConsumerState<ImageDetailPage> {
     final storeId = widget.photo.storeId;
 
     if (storeId.isEmpty) {
-      throw Exception('Store ID is null or empty');
+      return null;
     }
 
     return storeController.getStoreById(
@@ -55,7 +55,10 @@ class _ImageDetailPageState extends ConsumerState<ImageDetailPage> {
     );
   }
 
-  String formatAddress(String fullAddress) {
+  String? formatAddress(String? fullAddress) {
+    if (fullAddress == null || fullAddress.isEmpty) {
+      return null;
+    }
     final int postalCodeIndex = fullAddress.indexOf('〒');
     final String postalCode = fullAddress.substring(
         postalCodeIndex, fullAddress.indexOf(' ', postalCodeIndex));
@@ -91,12 +94,14 @@ class _ImageDetailPageState extends ConsumerState<ImageDetailPage> {
                   return const Center(child: CircularProgressIndicator());
                 } else if (snapshot.hasError) {
                   return Center(child: Text('Error: ${snapshot.error}'));
-                } else if (!snapshot.hasData || snapshot.data == null) {
-                  return const Center(
-                    child: Text('No store information available'),
-                  );
-                } else {
-                  final store = snapshot.data!;
+                }
+                // else if (!snapshot.hasData || snapshot.data == null) {
+                //   return const Center(
+                //     child: Text('No store information available'),
+                //   );
+                // }
+                else {
+                  final store = snapshot.data;
                   return PageView.builder(
                     controller: _pageController,
                     itemCount: 1,
@@ -110,11 +115,12 @@ class _ImageDetailPageState extends ConsumerState<ImageDetailPage> {
                         ),
                         child: ImageDetailCard(
                           photoUrl: widget.photo.url,
-                          storeName: store.name,
+                          storeName: store?.name,
                           dateTime: DateTime.now(),
-                          address: formatAddress(store.address),
-                          storeUrl: store.website,
-                          storeImageUrls: store.imageUrls,
+                          address: formatAddress(store?.address),
+                          storeUrl: store?.website,
+                          storeImageUrls: store?.imageUrls,
+                          showCardBack: widget.photo.storeId.isNotEmpty,
                         ),
                       );
                     },


### PR DESCRIPTION
## 関連のタスク issue
<!-- Notionリンクを記載  -->
https://www.notion.so/masakisato/0e4aaaf3a9e04873aa6113c898fa9364?v=a97d99f44f0944eb95eeb2d0a0747550&p=8b82ea8a96a845e684b8dbca767ae527&pm=s

## 対応したこと
<!-- 実装の概要を箇条書きする  -->
- storeIdが空の時は、カード裏面を表示しないように変更。
- photoUrlsをPhoto型に変更。
- addressの表示形式をFigmaに合わせて修正。
- カード裏面の表示形式変更（7日の営業時間を表示する形式）

## 未解決事項
<!-- 別PRで対応するような状況があれば記載  -->  

- 　別PRでカード裏面の余白を減らす予定（iPhoneSEの時に営業時間をもっと表示させるため）

## 実際の挙動
<!-- UIに関わるようであればスクリーンショット、動きのあるものは動画 or GIF  -->  
◽️storeIdに値が入っている場合（iphone15)
![スクリーンショット 2024-08-10 18 46 51](https://github.com/user-attachments/assets/ec81fb09-5dc1-4cb2-bb42-3e5b588d04a7)
![スクリーンショット 2024-08-10 18 46 58](https://github.com/user-attachments/assets/59ada3a6-1c45-43b5-934a-789268fe8a5b)


◽️storeIdに値が入っている場合（iphoneSE)
![スクリーンショット 2024-08-10 18 43 39](https://github.com/user-attachments/assets/f3980f2a-6723-44a6-8e7f-02cadaa6e927)
![スクリーンショット 2024-08-10 18 43 53](https://github.com/user-attachments/assets/aec6a182-f4d3-4bf6-9742-95e19fd7a076)


◽️storeIdに値が入っていない場合
![スクリーンショット 2024-08-10 18 47 57](https://github.com/user-attachments/assets/da6c1744-bfd1-4121-b413-f90fa15b7eac)



<!-- 入力エリアにドラッグ&ドロップしてアップロード  -->

## チェックリスト
<!-- 空白を消して`x`をつける  -->  
- [x] 実装完了後、問題が起こっていないか実際に動作確認したか  
- [x] 補足があった方が良い/重点的にレビューが欲しい箇所にGitHub上でコメントをしたか

## その他コメント

<!-- 何かあれば！  -->
