### PR TITLE
[TAS-189] / firestoreでstoreIdを更新する

### DIFF
--- a/lib/core/router.dart
+++ b/lib/core/router.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
-import '../features/photo/photo.dart';
 import '../view/classify_start_page.dart';
 import '../view/home_page.dart';
 import '../view/image_detail_page.dart';
@@ -48,7 +47,7 @@ final routerProvider = Provider(
           final args = state.extra! as Map<String, dynamic>;
           return ImageDetailPage(
             index: args['index'] as int,
-            photo: args['photo'] as Photo,
+            photoId: args['photoId'] as String,
           );
         },
       ),

--- a/lib/features/auth/auth_repository.dart
+++ b/lib/features/auth/auth_repository.dart
@@ -71,26 +71,6 @@ class AuthRepository {
     return (accessToken: accessToken, userId: userId);
   }
 
-  /// [ClassifyPhotosStatus]を[ClassifyPhotosStatus.processing]に更新するためのメソッド
-  ///
-  /// 初回サインアップ後で[AuthedUser]ドキュメントが存在していないようであればドキュメントを新規作成した上で更新する。
-  Future<void> upsertClassifyPhotosStatus(String userId) async {
-    final userDoc = authedUsersRef.doc(userId);
-    final userDocSnapshot = await userDoc.get();
-    final AuthedUser authedUser;
-    if (userDocSnapshot.exists) {
-      authedUser = userDocSnapshot
-          .data()!
-          .copyWith(classifyPhotosStatus: ClassifyPhotosStatus.processing);
-    } else {
-      authedUser = const AuthedUser(
-        classifyPhotosStatus: ClassifyPhotosStatus.processing,
-      );
-    }
-    // ドキュメントが存在しない場合は新規作成、存在する場合は中身を全て置き換え
-    await userDoc.set(authedUser);
-  }
-
   Stream<AuthedUser> subscribeAuthedUser() {
     return authedUsersRef
         .doc(_auth.currentUser?.uid)

--- a/lib/features/photo/photo.dart
+++ b/lib/features/photo/photo.dart
@@ -21,6 +21,9 @@ class Photo with _$Photo {
     @Default(UnionTimestamp.serverTimestamp())
     UnionTimestamp updatedAt,
 
+    /// FirebaseStorageに保存された写真の周辺店舗のIdリスト
+    @Default(<String>[]) List<String> areaStoreIds,
+
     /// FirebaseStorageに保存された写真のURL
     @Default('') String url,
 

--- a/lib/features/photo/photo.freezed.dart
+++ b/lib/features/photo/photo.freezed.dart
@@ -31,6 +31,9 @@ mixin _$Photo {
   @serverTimestampConverter
   UnionTimestamp get updatedAt => throw _privateConstructorUsedError;
 
+  /// FirebaseStorageに保存された写真の周辺店舗のIdリスト
+  List<String> get areaStoreIds => throw _privateConstructorUsedError;
+
   /// FirebaseStorageに保存された写真のURL
   String get url => throw _privateConstructorUsedError;
 
@@ -61,6 +64,7 @@ abstract class $PhotoCopyWith<$Res> {
       {String id,
       @timestampConverter UnionTimestamp createdAt,
       @serverTimestampConverter UnionTimestamp updatedAt,
+      List<String> areaStoreIds,
       String url,
       String category,
       String userId,
@@ -88,6 +92,7 @@ class _$PhotoCopyWithImpl<$Res, $Val extends Photo>
     Object? id = null,
     Object? createdAt = null,
     Object? updatedAt = null,
+    Object? areaStoreIds = null,
     Object? url = null,
     Object? category = null,
     Object? userId = null,
@@ -107,6 +112,10 @@ class _$PhotoCopyWithImpl<$Res, $Val extends Photo>
           ? _value.updatedAt
           : updatedAt // ignore: cast_nullable_to_non_nullable
               as UnionTimestamp,
+      areaStoreIds: null == areaStoreIds
+          ? _value.areaStoreIds
+          : areaStoreIds // ignore: cast_nullable_to_non_nullable
+              as List<String>,
       url: null == url
           ? _value.url
           : url // ignore: cast_nullable_to_non_nullable
@@ -166,6 +175,7 @@ abstract class _$$PhotoImplCopyWith<$Res> implements $PhotoCopyWith<$Res> {
       {String id,
       @timestampConverter UnionTimestamp createdAt,
       @serverTimestampConverter UnionTimestamp updatedAt,
+      List<String> areaStoreIds,
       String url,
       String category,
       String userId,
@@ -194,6 +204,7 @@ class __$$PhotoImplCopyWithImpl<$Res>
     Object? id = null,
     Object? createdAt = null,
     Object? updatedAt = null,
+    Object? areaStoreIds = null,
     Object? url = null,
     Object? category = null,
     Object? userId = null,
@@ -246,6 +257,7 @@ class _$PhotoImpl extends _Photo {
       this.createdAt = const UnionTimestamp.serverTimestamp(),
       @serverTimestampConverter
       this.updatedAt = const UnionTimestamp.serverTimestamp(),
+      this.areaStoreIds = const <String>[],
       this.url = '',
       this.category = '',
       this.userId = '',
@@ -272,6 +284,11 @@ class _$PhotoImpl extends _Photo {
   @JsonKey()
   @serverTimestampConverter
   final UnionTimestamp updatedAt;
+
+  /// FirebaseStorageに保存された写真の周辺店舗のIdリスト
+  @override
+  @JsonKey()
+  final List<String> areaStoreIds;
 
   /// FirebaseStorageに保存された写真のURL
   @override
@@ -301,7 +318,7 @@ class _$PhotoImpl extends _Photo {
 
   @override
   String toString() {
-    return 'Photo(id: $id, createdAt: $createdAt, updatedAt: $updatedAt, url: $url, category: $category, userId: $userId, shotAt: $shotAt, storeId: $storeId)';
+    return 'Photo(id: $id, createdAt: $createdAt, updatedAt: $updatedAt, url: $url, areaStoreIds:$areaStoreIds ,category: $category, userId: $userId, shotAt: $shotAt, storeId: $storeId)';
   }
 
   @override
@@ -314,6 +331,8 @@ class _$PhotoImpl extends _Photo {
                 other.createdAt == createdAt) &&
             (identical(other.updatedAt, updatedAt) ||
                 other.updatedAt == updatedAt) &&
+            (identical(other.areaStoreIds, areaStoreIds) ||
+                other.areaStoreIds == areaStoreIds) &&
             (identical(other.url, url) || other.url == url) &&
             (identical(other.category, category) ||
                 other.category == category) &&
@@ -324,8 +343,8 @@ class _$PhotoImpl extends _Photo {
 
   @JsonKey(ignore: true)
   @override
-  int get hashCode => Object.hash(runtimeType, id, createdAt, updatedAt, url,
-      category, userId, shotAt, storeId);
+  int get hashCode => Object.hash(runtimeType, id, createdAt, updatedAt,
+      areaStoreIds, url, category, userId, shotAt, storeId);
 
   @JsonKey(ignore: true)
   @override
@@ -346,6 +365,7 @@ abstract class _Photo extends Photo {
       {final String id,
       @timestampConverter final UnionTimestamp createdAt,
       @serverTimestampConverter final UnionTimestamp updatedAt,
+      final List<String> areaStoreIds,
       final String url,
       final String category,
       final String userId,
@@ -369,6 +389,10 @@ abstract class _Photo extends Photo {
   /// 更新日時
   @serverTimestampConverter
   UnionTimestamp get updatedAt;
+  @override
+
+  /// FirebaseStorageに保存された写真の周辺店舗のIdリスト
+  List<String> get areaStoreIds;
   @override
 
   /// FirebaseStorageに保存された写真のURL

--- a/lib/features/photo/photo.g.dart
+++ b/lib/features/photo/photo.g.dart
@@ -15,19 +15,23 @@ _$PhotoImpl _$$PhotoImplFromJson(Map<String, dynamic> json) => _$PhotoImpl(
           ? const UnionTimestamp.serverTimestamp()
           : serverTimestampConverter.fromJson(json['updatedAt'] as Object),
       url: json['url'] as String? ?? '',
+      areaStoreIds: (json['areaStoreIds'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList() ?? const <String>[],
       category: json['category'] as String? ?? '',
       userId: json['userId'] as String? ?? '',
       shotAt: json['shotAt'] == null
           ? const UnionTimestamp.serverTimestamp()
           : timestampConverter.fromJson(json['shotAt'] as Object),
       storeId: json['storeId'] as String? ?? '',
-    );
+);
 
 Map<String, dynamic> _$$PhotoImplToJson(_$PhotoImpl instance) =>
     <String, dynamic>{
       'id': instance.id,
       'createdAt': timestampConverter.toJson(instance.createdAt),
       'updatedAt': serverTimestampConverter.toJson(instance.updatedAt),
+      'areaStoreIds': instance.areaStoreIds,
       'url': instance.url,
       'category': instance.category,
       'userId': instance.userId,

--- a/lib/features/photo/photo_controller.dart
+++ b/lib/features/photo/photo_controller.dart
@@ -25,7 +25,7 @@ class PhotoController {
     return _photoRepository.downloadPhotos(userId: userId);
   }
 
-  // TODO: Photo?の部分はあとで書き換える。
+  // TODO(kim): Photo?の部分はあとで書き換える。
   Future<Photo?> downloadPhoto({
     required String userId,
     required String photoId,

--- a/lib/features/photo/photo_controller.dart
+++ b/lib/features/photo/photo_controller.dart
@@ -1,6 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../auth/auth_repository.dart';
 import 'photo.dart';
 import 'photo_repository.dart';
 
@@ -17,22 +16,21 @@ class PhotoController {
 
   final Ref _ref;
 
-  AuthRepository get _authRepository => _ref.read(authRepositoryProvider);
-
   PhotoRepository get _photoRepository => _ref.read(photoRepositoryProvider);
-
-  /// 画像分類ステータスの更新用メソッド
-  Future<void> upsertClassifyPhotosStatus({
-    required String userId,
-  }) async {
-    await _authRepository.upsertClassifyPhotosStatus(userId);
-  }
 
   /// 写真ダウンロード用メソッド
   Future<List<Photo>> downloadPhotos({
     required String userId,
   }) async {
     return _photoRepository.downloadPhotos(userId: userId);
+  }
+
+  // TODO: Photo?の部分はあとで書き換える。
+  Future<Photo?> downloadPhoto({
+    required String userId,
+    required String photoId,
+  }) async {
+    return _photoRepository.downloadPhoto(userId: userId, photoId: photoId);
   }
 
   Future<String> getStoreNameByStoreId({
@@ -52,6 +50,19 @@ class PhotoController {
     return _photoRepository.getPhotoById(
       userId: userId,
       photoId: photoId,
+    );
+  }
+
+  /// 画像分類ステータスの更新用メソッド
+  Future<void> updateStoreIdForPhoto({
+    required String userId,
+    required String photoId,
+    required String storeId,
+  }) async {
+    await _photoRepository.updateStoreIdForPhoto(
+      userId,
+      photoId,
+      storeId,
     );
   }
 }

--- a/lib/features/photo/photo_repository.dart
+++ b/lib/features/photo/photo_repository.dart
@@ -146,7 +146,7 @@ class PhotoRepository {
     }
   }
 
-  // TODO: Photo?の部分はあとで書き換える。
+  // TODO(kim): Photo?の部分はあとで書き換える。
   Future<Photo?> downloadPhoto({
     required String userId,
     required String photoId,

--- a/lib/features/store/store_controller.dart
+++ b/lib/features/store/store_controller.dart
@@ -1,6 +1,5 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../auth/auth_repository.dart';
 import 'store.dart';
 import 'store_repository.dart';
 
@@ -17,15 +16,13 @@ class StoreController {
 
   final Ref _ref;
 
-  AuthRepository get _authRepository => _ref.read(authRepositoryProvider);
-
   StoreRepository get _storeRepository => _ref.read(storeRepositoryProvider);
 
-  /// 画像分類ステータスの更新用メソッド
-  Future<void> upsertClassifyPhotosStatus({
-    required String userId,
+  /// 写真ダウンロード用メソッド
+  Future<List<Store>> getStoresInfo({
+    required List<String> areaStoreIds,
   }) async {
-    await _authRepository.upsertClassifyPhotosStatus(userId);
+    return _storeRepository.getStoresInfo(areaStoreIds: areaStoreIds);
   }
 
   Future<Store?> getStoreById({

--- a/lib/features/store/store_repository.dart
+++ b/lib/features/store/store_repository.dart
@@ -47,4 +47,31 @@ class StoreRepository {
       return null;
     }
   }
+
+  // areaStoreIdsのリストを引数に、Storesのリストを受け取る処理を追加
+  Future<List<Store>> getStoresInfo({
+    required List<String> areaStoreIds,
+  }) async {
+    try {
+      // `in` クエリを使用して、複数の storeId に一致するドキュメントを一度に取得する
+      final querySnapshot = await FirebaseFirestore.instance
+          .collection('stores')
+          .where(FieldPath.documentId, whereIn: areaStoreIds)
+          .get();
+
+      // ドキュメントを Store オブジェクトに変換してリストにする
+      final stores = querySnapshot.docs.map((doc) {
+        final data = doc.data();
+        return Store.fromJson({
+          ...data,
+          'id': doc.id, // ドキュメントIDをセット
+        });
+      }).toList();
+
+      return stores;
+    } on Exception catch (e) {
+      logger.e('An error occurred while fetching stores: $e');
+      return [];
+    }
+  }
 }

--- a/lib/features/swipe_photo/swipe_photo_controller.dart
+++ b/lib/features/swipe_photo/swipe_photo_controller.dart
@@ -2,8 +2,6 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:typed_data';
 
-import 'package:exif/exif.dart';
-import 'package:flutter/material.dart';
 import 'package:flutter_image_compress/flutter_image_compress.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:photo_manager/photo_manager.dart';
@@ -109,9 +107,6 @@ class _PhotoListNotifier extends AutoDisposeAsyncNotifier<List<AssetEntity>> {
 
         unawaited(
           photo.file.then((value) async {
-            final data = await readExifFromFile(value!);
-            debugPrint('exifパッケージ exif: $data');
-
             if (photo.longitude != null && photo.latitude != null) {
               // 写真情報をサーバーに登録
               await ref.read(photoRepositoryProvider).registerStoreInfo(

--- a/lib/features/swipe_photo/swipe_photo_controller.dart
+++ b/lib/features/swipe_photo/swipe_photo_controller.dart
@@ -107,10 +107,6 @@ class _PhotoListNotifier extends AutoDisposeAsyncNotifier<List<AssetEntity>> {
         final result =
             await ref.read(authControllerProvider).signInWithGoogle();
 
-        debugPrint('photo_managerパッケージ modifiedPhotoId: $modifiedPhotoId');
-        debugPrint('photo_managerパッケージ photo: $photo');
-        debugPrint('photo_managerパッケージ latitude: ${photo.latitude}');
-        debugPrint('photo_managerパッケージ longitude: ${photo.longitude}');
         unawaited(
           photo.file.then((value) async {
             final data = await readExifFromFile(value!);

--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_staggered_grid_view/flutter_staggered_grid_view.dart';
 import 'package:go_router/go_router.dart';
 
+import '../core/themes.dart';
 import '../features/auth/auth_controller.dart';
 import '../features/auth/authed_user.dart';
 import '../features/photo/photo.dart';
@@ -130,11 +131,11 @@ class _HomePageState extends ConsumerState<HomePage>
     }
 
     return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16),
+      padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 6),
       child: MasonryGridView.count(
         crossAxisCount: 2,
-        mainAxisSpacing: 8,
-        crossAxisSpacing: 8,
+        mainAxisSpacing: 6,
+        crossAxisSpacing: 6,
         itemBuilder: (context, index) {
           final photo = filteredPhotos[index];
 
@@ -153,13 +154,13 @@ class _HomePageState extends ConsumerState<HomePage>
               child: DecoratedBox(
                 decoration: BoxDecoration(
                   border: Border.all(
-                    color: Colors.grey,
+                    color: Themes.gray[900]!,
                     width: 2,
                   ),
-                  borderRadius: BorderRadius.circular(16),
+                  borderRadius: BorderRadius.circular(8),
                 ),
                 child: ClipRRect(
-                  borderRadius: BorderRadius.circular(14),
+                  borderRadius: BorderRadius.circular(8),
                   child: Image.network(
                     photo.url,
                     fit: BoxFit.cover,

--- a/lib/view/home_page.dart
+++ b/lib/view/home_page.dart
@@ -72,8 +72,6 @@ class _HomePageState extends ConsumerState<HomePage>
 
     setState(() {
       photoUrls = result.where((e) => e.url.isNotEmpty).toList();
-      debugPrint('photoUrls: $photoUrls');
-      debugPrint('result: $result');
     });
   }
 
@@ -139,11 +137,6 @@ class _HomePageState extends ConsumerState<HomePage>
         crossAxisSpacing: 8,
         itemBuilder: (context, index) {
           final photo = filteredPhotos[index];
-
-          // debugPrint('homePage userId: ${photo.userId}');
-          // debugPrint('homePage photoId: ${photo.id}');
-          debugPrint('homePage photo.areaStoreIds: ${photo.areaStoreIds}');
-          debugPrint('homePage photo: $photo');
 
           return Hero(
             tag: photo,

--- a/lib/view/image_detail/card_back.dart
+++ b/lib/view/image_detail/card_back.dart
@@ -78,7 +78,10 @@ class CardBack extends ConsumerWidget {
             right: 16,
           ),
           decoration: BoxDecoration(
-            border: Border.all(),
+            border: Border.all(
+              color: Themes.gray[900]!,
+              width: 2,
+            ),
             borderRadius: BorderRadius.circular(8),
           ),
         ),
@@ -127,6 +130,7 @@ class CardBack extends ConsumerWidget {
             decoration: BoxDecoration(
               border: Border.all(
                 color: Themes.gray[900]!,
+                width: 2,
               ),
               borderRadius: BorderRadius.circular(8),
             ),

--- a/lib/view/image_detail/card_back.dart
+++ b/lib/view/image_detail/card_back.dart
@@ -17,7 +17,6 @@ class CardBack extends ConsumerWidget {
     required this.storeName,
     required this.storeImageUrls,
     this.openTime,
-    this.holiday,
     this.address,
     this.storeUrl,
     this.storeOpeningHours,
@@ -31,7 +30,6 @@ class CardBack extends ConsumerWidget {
   final String storeName;
   final List<String> storeImageUrls;
   final String? openTime;
-  final String? holiday;
   final String? address;
   final String? storeUrl;
   final Map<String, String>? storeOpeningHours;

--- a/lib/view/image_detail/card_back.dart
+++ b/lib/view/image_detail/card_back.dart
@@ -127,7 +127,9 @@ class CardBack extends ConsumerWidget {
               right: 16,
             ),
             decoration: BoxDecoration(
-              border: Border.all(),
+              border: Border.all(
+                color: Themes.gray[900]!,
+              ),
               borderRadius: BorderRadius.circular(8),
             ),
             child: Column(
@@ -137,9 +139,11 @@ class CardBack extends ConsumerWidget {
                   storeName,
                   style: Theme.of(context).textTheme.titleMedium,
                 ),
-                const Padding(
-                  padding: EdgeInsets.symmetric(vertical: 16),
-                  child: Divider(),
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                  child: Divider(
+                    color: Themes.gray[900],
+                  ),
                 ),
                 if (storeImageUrls.isNotEmpty)
                   SizedBox(
@@ -182,9 +186,11 @@ class CardBack extends ConsumerWidget {
                       ],
                     ),
                   ),
-                const Padding(
-                  padding: EdgeInsets.symmetric(vertical: 16),
-                  child: Divider(),
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                  child: Divider(
+                    color: Themes.gray[900],
+                  ),
                 ),
                 if (address != null)
                   Row(
@@ -218,9 +224,11 @@ class CardBack extends ConsumerWidget {
                       ),
                     ],
                   ),
-                const Padding(
-                  padding: EdgeInsets.symmetric(vertical: 18),
-                  child: Divider(),
+                Padding(
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                  child: Divider(
+                    color: Themes.gray[900],
+                  ),
                 ),
                 if (storeOpeningHours != null)
                   Expanded(
@@ -283,7 +291,10 @@ class CardBack extends ConsumerWidget {
                       child: DecoratedBox(
                         decoration: BoxDecoration(
                           color: Themes.gray[200],
-                          border: Border.all(),
+                          border: Border.all(
+                            color: Themes.gray[900]!,
+                            width: 2,
+                          ),
                           borderRadius: const BorderRadius.only(
                             bottomRight: Radius.circular(8),
                             bottomLeft: Radius.circular(8),
@@ -313,7 +324,10 @@ class CardBack extends ConsumerWidget {
               borderRadius: const BorderRadius.only(
                 topLeft: Radius.circular(8),
               ),
-              border: Border.all(),
+              border: Border.all(
+                color: Themes.gray[900]!,
+                width: 2,
+              ),
               color: Themes.gray[100],
             ),
             child: const Icon(Icons.refresh),

--- a/lib/view/image_detail/card_front.dart
+++ b/lib/view/image_detail/card_front.dart
@@ -42,7 +42,10 @@ class CardFront extends StatelessWidget {
               right: 16,
             ),
             decoration: BoxDecoration(
-              border: Border.all(),
+              border: Border.all(
+                color: Themes.gray[900]!,
+                width: 2,
+              ),
               borderRadius: BorderRadius.circular(8),
             ),
             child: Column(
@@ -64,7 +67,10 @@ class CardFront extends StatelessWidget {
                         overflow: TextOverflow.ellipsis,
                         style: context.textTheme.titleMedium,
                       ),
-                      if (showCardBack) const Divider(),
+                      if (showCardBack)
+                        Divider(
+                          color: Themes.gray[900],
+                        ),
                       if (showCardBack)
                         Row(
                           mainAxisSize: MainAxisSize.min,
@@ -94,7 +100,10 @@ class CardFront extends StatelessWidget {
                 borderRadius: const BorderRadius.only(
                   topRight: Radius.circular(8),
                 ),
-                border: Border.all(),
+                border: Border.all(
+                  color: Themes.gray[900]!,
+                  width: 2,
+                ),
                 color: Themes.gray[100],
               ),
               child: const Icon(Icons.refresh),

--- a/lib/view/image_detail/image_detail_card.dart
+++ b/lib/view/image_detail/image_detail_card.dart
@@ -5,15 +5,23 @@ import 'card_back.dart';
 import 'card_front.dart';
 
 class ImageDetailCard extends StatefulWidget {
-  const ImageDetailCard(
-      {super.key,
-      required this.storeName,
-      required this.dateTime,
-      required this.address,
-      required this.photoUrl,
-      required this.storeUrl,
-      required this.storeImageUrls,});
+  const ImageDetailCard({
+    super.key,
+    required this.onSelected,
+    required this.userId,
+    required this.photoId,
+    required this.areaStoreIds,
+    required this.storeName,
+    required this.dateTime,
+    required this.address,
+    required this.photoUrl,
+    required this.storeUrl,
+    required this.storeImageUrls,
+  });
 
+  final String userId;
+  final String photoId;
+  final List<String> areaStoreIds;
   final String storeName;
   final DateTime dateTime;
   final String address;
@@ -21,11 +29,19 @@ class ImageDetailCard extends StatefulWidget {
   final String storeUrl;
   final List<String> storeImageUrls;
 
+  final void Function() onSelected;
+
   @override
   State<ImageDetailCard> createState() => _ImageDetailCardState();
 }
 
 class _ImageDetailCardState extends State<ImageDetailCard> {
+  String get userId => widget.userId;
+
+  String get photoId => widget.photoId;
+
+  List<String> get areaStoreIds => widget.areaStoreIds;
+
   String get storeName => widget.storeName;
 
   DateTime get dateTime => widget.dateTime;
@@ -52,6 +68,10 @@ class _ImageDetailCardState extends State<ImageDetailCard> {
         address: address,
       ),
       back: CardBack(
+        onSelected: widget.onSelected,
+        userId: userId,
+        photoId: photoId,
+        areaStoreIds: areaStoreIds,
         isLinked: true,
         storeName: storeName,
         storeImageUrls: storeImageUrls,

--- a/lib/view/image_detail/image_detail_card.dart
+++ b/lib/view/image_detail/image_detail_card.dart
@@ -85,7 +85,6 @@ class _ImageDetailCardState extends State<ImageDetailCard> {
               isLinked: true,
               storeName: storeName,
               storeImageUrls: storeImageUrls,
-              holiday: '土曜',
               address: address,
               storeUrl: storeUrl,
               storeOpeningHours: storeOpeningHours,

--- a/lib/view/image_detail/shop_list_dialog.dart
+++ b/lib/view/image_detail/shop_list_dialog.dart
@@ -53,6 +53,7 @@ Future<void> showShopListDialog(
                         shape: BoxShape.circle,
                       ),
                       child: IconButton(
+                        padding: EdgeInsets.zero,
                         onPressed: () {
                           Navigator.of(context).pop();
                         },
@@ -128,7 +129,8 @@ Future<void> showShopListDialog(
                                                 stores[shopNo].imageUrls[index];
                                             return Padding(
                                               padding: const EdgeInsets.only(
-                                                  left: 10,),
+                                                left: 10,
+                                              ),
                                               child: ClipRRect(
                                                 borderRadius:
                                                     BorderRadius.circular(8),

--- a/lib/view/image_detail/shop_list_dialog.dart
+++ b/lib/view/image_detail/shop_list_dialog.dart
@@ -22,34 +22,20 @@ Future<void> showShopListDialog(
   required List<Store> stores,
   required void Function() onSelected,
 }) async {
-  var currentIndex = 0;
-
-  void showNextStores(StateSetter setState) {
-    setState(() {
-      currentIndex += 3;
-      if (currentIndex >= stores.length) {
-        currentIndex = 0; // 最後まで行ったら最初に戻る
-      }
-      shopNoSelected = 0; // ページを変更するたびにリセット
-    });
-  }
-
   await showDialog<void>(
     context: context,
     barrierDismissible: false,
     builder: (BuildContext context) {
       return StatefulBuilder(
         builder: (context, setState) {
-          final selectedStores =
-              stores.skip(currentIndex).take(3).toList(); // 現在のインデックスから3件を取得
-
           return AlertDialog(
-            insetPadding: const EdgeInsets.all(20),
+            insetPadding: const EdgeInsets.symmetric(horizontal: 24.0),
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(10),
             ),
             content: Container(
-              width: context.screenWidth,
+              width: context.screenWidth * 0.9,
+              height: context.screenHeight * 0.85,
               decoration: BoxDecoration(
                 border: Border.all(color: Colors.white),
                 borderRadius: BorderRadius.circular(10),
@@ -78,133 +64,112 @@ Future<void> showShopListDialog(
                       ),
                     ),
                   ),
-                  const Spacer(),
+                  const Gap(10),
                   Text(
                     '写真を撮った店舗を選んでください',
                     style: context.textTheme.titleSmall,
                   ),
                   const Gap(10),
-                  for (int shopNo = 0;
-                      shopNo < selectedStores.length;
-                      shopNo++) ...{
-                    GestureDetector(
-                      onTap: () {
-                        setState(() {
-                          shopNoSelected = shopNo;
-                        });
-                      },
-                      child: Stack(
-                        children: [
-                          Container(
-                            margin: const EdgeInsets.only(
-                              top: 7,
-                              bottom: 7,
-                              left: 10,
-                              right: 10,
-                            ),
-                            padding: const EdgeInsets.only(
-                              top: 5,
-                              bottom: 10,
-                            ),
-                            decoration: BoxDecoration(
-                              border: Border.all(
-                                width: 2,
-                                color: shopNoSelected == shopNo
-                                    ? Themes.mainOrange
-                                    : Themes.gray.shade300,
-                              ),
-                              borderRadius: BorderRadius.circular(8),
-                              boxShadow: [
-                                BoxShadow(
-                                  color: Colors.grey.withOpacity(0.5),
-                                  blurRadius: 3,
-                                  offset: const Offset(0, 5),
+                  Expanded(
+                    child: ListView.builder(
+                      itemCount: stores.length,
+                      itemBuilder: (context, shopNo) {
+                        return GestureDetector(
+                          onTap: () {
+                            setState(() {
+                              shopNoSelected = shopNo;
+                            });
+                          },
+                          child: Stack(
+                            children: [
+                              Container(
+                                margin: const EdgeInsets.symmetric(
+                                  vertical: 7,
+                                  horizontal: 10,
                                 ),
-                              ],
-                              color: Colors.white,
-                            ),
-                            child: Column(
-                              children: [
-                                Padding(
-                                  padding: const EdgeInsets.only(
-                                    left: 10,
-                                    bottom: 5,
+                                padding: const EdgeInsets.symmetric(
+                                  vertical: 5,
+                                  horizontal: 10,
+                                ),
+                                decoration: BoxDecoration(
+                                  border: Border.all(
+                                    width: 2,
+                                    color: shopNoSelected == shopNo
+                                        ? Themes.mainOrange
+                                        : Themes.gray.shade300,
                                   ),
-                                  child: Align(
-                                    alignment: Alignment.topLeft,
-                                    child: Text(
-                                      selectedStores[shopNo].name,
+                                  borderRadius: BorderRadius.circular(8),
+                                  boxShadow: [
+                                    BoxShadow(
+                                      color: Colors.grey.withOpacity(0.5),
+                                      blurRadius: 3,
+                                      offset: const Offset(0, 5),
+                                    ),
+                                  ],
+                                  color: Colors.white,
+                                ),
+                                child: Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    Text(
+                                      stores[shopNo].name,
                                       style: context.textTheme.bodySmall,
                                     ),
-                                  ),
+                                    const Gap(5),
+                                    SizedBox(
+                                      height: 110,
+                                      child: Scrollbar(
+                                        child: ListView.builder(
+                                          scrollDirection: Axis.horizontal,
+                                          itemCount:
+                                              stores[shopNo].imageUrls.length,
+                                          itemBuilder: (context, index) {
+                                            final photoUrl =
+                                                stores[shopNo].imageUrls[index];
+                                            return Padding(
+                                              padding: const EdgeInsets.only(
+                                                  left: 10),
+                                              child: ClipRRect(
+                                                borderRadius:
+                                                    BorderRadius.circular(8),
+                                                child: ScalablePhoto(
+                                                  height: 100,
+                                                  width: 125,
+                                                  photoUrl: photoUrl,
+                                                ),
+                                              ),
+                                            );
+                                          },
+                                        ),
+                                      ),
+                                    ),
+                                  ],
                                 ),
-                                SizedBox(
-                                  height: 110,
-                                  child: Scrollbar(
-                                    child: ListView.builder(
-                                      scrollDirection: Axis.horizontal,
-                                      itemCount: selectedStores[shopNo]
-                                          .imageUrls
-                                          .length,
-                                      itemBuilder: (context, index) {
-                                        final photoUrl = selectedStores[shopNo]
-                                            .imageUrls[index];
-                                        return Padding(
-                                          padding:
-                                              const EdgeInsets.only(left: 10),
-                                          child: ClipRRect(
-                                            borderRadius:
-                                                BorderRadius.circular(8),
-                                            child: ScalablePhoto(
-                                              height: 100,
-                                              width: 125,
-                                              photoUrl: photoUrl,
-                                            ),
-                                          ),
-                                        );
-                                      },
+                              ),
+                              if (shopNo == shopNoSelected)
+                                Positioned(
+                                  right: 0,
+                                  top: 0,
+                                  child: Container(
+                                    width: 28,
+                                    height: 28,
+                                    decoration: const BoxDecoration(
+                                      color: Themes.mainOrange,
+                                      shape: BoxShape.circle,
+                                    ),
+                                    child: const Icon(
+                                      Icons.check,
+                                      color: Colors.white,
+                                      size: 20,
                                     ),
                                   ),
                                 ),
-                              ],
-                            ),
+                            ],
                           ),
-                          if (shopNo == shopNoSelected)
-                            Positioned(
-                              right: 0,
-                              top: 0,
-                              child: Container(
-                                width: 28,
-                                height: 28,
-                                decoration: const BoxDecoration(
-                                  color: Themes.mainOrange,
-                                  shape: BoxShape.circle,
-                                ),
-                                child: const Icon(
-                                  Icons.check,
-                                  color: Colors.white,
-                                  size: 20,
-                                ),
-                              ),
-                            ),
-                        ],
-                      ),
+                        );
+                      },
                     ),
-                  },
-                  const Gap(10),
-                  if (stores.length > 3)
-                    Align(
-                      alignment: Alignment.centerRight,
-                      child: TextButton(
-                        onPressed: () => showNextStores(setState),
-                        child: const Text(
-                          '次へ',
-                          style: TextStyle(
-                            color: Themes.gray,
-                          ),
-                        ),
-                      ),
-                    ),
+                  ),
                   const Gap(16),
                   Padding(
                     padding: EdgeInsets.symmetric(
@@ -220,7 +185,7 @@ Future<void> showShopListDialog(
                               .updateStoreIdForPhoto(
                                 userId: userId,
                                 photoId: photoId,
-                                storeId: selectedStores[shopNoSelected].id,
+                                storeId: stores[shopNoSelected].id,
                               );
                           onSelected();
                           shopNoSelected = 0;
@@ -229,7 +194,6 @@ Future<void> showShopListDialog(
                       ),
                     ),
                   ),
-                  const Spacer(),
                 ],
               ),
             ),

--- a/lib/view/image_detail/shop_list_dialog.dart
+++ b/lib/view/image_detail/shop_list_dialog.dart
@@ -29,7 +29,7 @@ Future<void> showShopListDialog(
       return StatefulBuilder(
         builder: (context, setState) {
           return AlertDialog(
-            insetPadding: const EdgeInsets.symmetric(horizontal: 24.0),
+            insetPadding: const EdgeInsets.symmetric(horizontal: 24),
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(10),
             ),
@@ -128,7 +128,7 @@ Future<void> showShopListDialog(
                                                 stores[shopNo].imageUrls[index];
                                             return Padding(
                                               padding: const EdgeInsets.only(
-                                                  left: 10),
+                                                  left: 10,),
                                               child: ClipRRect(
                                                 borderRadius:
                                                     BorderRadius.circular(8),

--- a/lib/view/image_detail/shop_list_dialog.dart
+++ b/lib/view/image_detail/shop_list_dialog.dart
@@ -30,6 +30,7 @@ Future<void> showShopListDialog(
       if (currentIndex >= stores.length) {
         currentIndex = 0; // 最後まで行ったら最初に戻る
       }
+      shopNoSelected = 0; // ページを変更するたびにリセット
     });
   }
 
@@ -41,10 +42,6 @@ Future<void> showShopListDialog(
         builder: (context, setState) {
           final selectedStores =
               stores.skip(currentIndex).take(3).toList(); // 現在のインデックスから3件を取得
-          final storeNames = selectedStores.map((store) => store.name).toList();
-          final storeImagesList =
-              selectedStores.map((store) => store.imageUrls).toList();
-          final selectedStoreId = selectedStores[shopNoSelected].id;
 
           return AlertDialog(
             insetPadding: const EdgeInsets.all(20),
@@ -136,7 +133,7 @@ Future<void> showShopListDialog(
                                   child: Align(
                                     alignment: Alignment.topLeft,
                                     child: Text(
-                                      storeNames[shopNo],
+                                      selectedStores[shopNo].name,
                                       style: context.textTheme.bodySmall,
                                     ),
                                   ),
@@ -146,10 +143,12 @@ Future<void> showShopListDialog(
                                   child: Scrollbar(
                                     child: ListView.builder(
                                       scrollDirection: Axis.horizontal,
-                                      itemCount: storeImagesList[shopNo].length,
+                                      itemCount: selectedStores[shopNo]
+                                          .imageUrls
+                                          .length,
                                       itemBuilder: (context, index) {
-                                        final photoUrl =
-                                            storeImagesList[shopNo][index];
+                                        final photoUrl = selectedStores[shopNo]
+                                            .imageUrls[index];
                                         return Padding(
                                           padding:
                                               const EdgeInsets.only(left: 10),
@@ -221,9 +220,10 @@ Future<void> showShopListDialog(
                               .updateStoreIdForPhoto(
                                 userId: userId,
                                 photoId: photoId,
-                                storeId: selectedStoreId,
+                                storeId: selectedStores[shopNoSelected].id,
                               );
                           onSelected();
+                          shopNoSelected = 0;
                         },
                         text: '決定',
                       ),

--- a/lib/view/image_detail/shop_list_dialog.dart
+++ b/lib/view/image_detail/shop_list_dialog.dart
@@ -1,179 +1,240 @@
 import 'dart:io';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:gap/gap.dart';
 
 import '../../core/build_context_extension.dart';
 import '../../core/themes.dart';
+import '../../features/photo/photo_controller.dart';
+import '../../features/store/store.dart';
 import '../widgets/custom_elevated_button.dart';
 import '../widgets/scalable_image.dart';
 
 List<File> shopList = [];
-int shopNo = 0;
-int shopNoSelected = 0;
+int shopNoSelected = 0; // 初期値を0に設定
 
 Future<void> showShopListDialog(
   BuildContext context, {
-  required String shopName,
-  required List<String> storeImageUrls,
+  required WidgetRef ref,
+  required String userId,
+  required String photoId,
+  required List<Store> stores,
   required void Function() onSelected,
 }) async {
+  var currentIndex = 0;
+
+  void showNextStores(StateSetter setState) {
+    setState(() {
+      currentIndex += 3;
+      if (currentIndex >= stores.length) {
+        currentIndex = 0; // 最後まで行ったら最初に戻る
+      }
+    });
+  }
+
   await showDialog<void>(
     context: context,
     barrierDismissible: false,
     builder: (BuildContext context) {
-      return AlertDialog(
-        insetPadding: const EdgeInsets.all(20),
-        shape: RoundedRectangleBorder(
-          borderRadius: BorderRadius.circular(10),
-        ),
-        content: Container(
-          width: context.screenWidth,
-          decoration: BoxDecoration(
-            border: Border.all(color: Colors.white),
-            borderRadius: BorderRadius.circular(10),
-          ),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Align(
-                alignment: Alignment.topRight,
-                child: Container(
-                  width: 32,
-                  height: 32,
-                  decoration: BoxDecoration(
-                    color: Themes.gray[50],
-                    shape: BoxShape.circle,
-                  ),
-                  child: IconButton(
-                    onPressed: () {
-                      Navigator.of(context).pop();
-                    },
-                    icon: Icon(Icons.close, size: 20, color: Themes.gray[800]),
-                  ),
-                ),
+      return StatefulBuilder(
+        builder: (context, setState) {
+          final selectedStores =
+              stores.skip(currentIndex).take(3).toList(); // 現在のインデックスから3件を取得
+          final storeNames = selectedStores.map((store) => store.name).toList();
+          final storeImagesList =
+              selectedStores.map((store) => store.imageUrls).toList();
+          final selectedStoreId = selectedStores[shopNoSelected].id;
+
+          return AlertDialog(
+            insetPadding: const EdgeInsets.all(20),
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(10),
+            ),
+            content: Container(
+              width: context.screenWidth,
+              decoration: BoxDecoration(
+                border: Border.all(color: Colors.white),
+                borderRadius: BorderRadius.circular(10),
               ),
-              const Spacer(),
-              Text(
-                '写真を撮った店舗を選んでください',
-                style: context.textTheme.titleSmall,
-              ),
-              const Gap(10),
-              for (shopNo = 0; shopNo < 3; shopNo++) ...{
-                Stack(
-                  children: [
-                    Container(
-                      margin: const EdgeInsets.only(
-                        top: 7,
-                        bottom: 7,
-                        left: 10,
-                        right: 10,
-                      ),
-                      padding: const EdgeInsets.only(
-                        top: 5,
-                        bottom: 10,
-                      ),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Align(
+                    alignment: Alignment.topRight,
+                    child: Container(
+                      width: 32,
+                      height: 32,
                       decoration: BoxDecoration(
-                        border: Border.all(
-                          width: 2,
-                          color: shopNoSelected == shopNo
-                              ? Themes.mainOrange
-                              : Themes.gray.shade300,
-                        ),
-                        borderRadius: BorderRadius.circular(8),
-                        boxShadow: [
-                          BoxShadow(
-                            color: Colors.grey.withOpacity(0.5),
-                            blurRadius: 3,
-                            offset: const Offset(0, 5),
-                          ),
-                        ],
-                        color: Colors.white,
+                        color: Themes.gray[50],
+                        shape: BoxShape.circle,
                       ),
-                      child: Column(
+                      child: IconButton(
+                        onPressed: () {
+                          Navigator.of(context).pop();
+                        },
+                        icon: Icon(
+                          Icons.close,
+                          size: 20,
+                          color: Themes.gray[800],
+                        ),
+                      ),
+                    ),
+                  ),
+                  const Spacer(),
+                  Text(
+                    '写真を撮った店舗を選んでください',
+                    style: context.textTheme.titleSmall,
+                  ),
+                  const Gap(10),
+                  for (int shopNo = 0;
+                      shopNo < selectedStores.length;
+                      shopNo++) ...{
+                    GestureDetector(
+                      onTap: () {
+                        setState(() {
+                          shopNoSelected = shopNo;
+                        });
+                      },
+                      child: Stack(
                         children: [
-                          Padding(
-                            padding: const EdgeInsets.only(
+                          Container(
+                            margin: const EdgeInsets.only(
+                              top: 7,
+                              bottom: 7,
                               left: 10,
-                              bottom: 5,
+                              right: 10,
                             ),
-                            child: Align(
-                              alignment: Alignment.topLeft,
-                              child: Text(
-                                shopName,
-                                style: context.textTheme.bodySmall,
+                            padding: const EdgeInsets.only(
+                              top: 5,
+                              bottom: 10,
+                            ),
+                            decoration: BoxDecoration(
+                              border: Border.all(
+                                width: 2,
+                                color: shopNoSelected == shopNo
+                                    ? Themes.mainOrange
+                                    : Themes.gray.shade300,
                               ),
+                              borderRadius: BorderRadius.circular(8),
+                              boxShadow: [
+                                BoxShadow(
+                                  color: Colors.grey.withOpacity(0.5),
+                                  blurRadius: 3,
+                                  offset: const Offset(0, 5),
+                                ),
+                              ],
+                              color: Colors.white,
                             ),
-                          ),
-                          SizedBox(
-                            height: 110,
-                            child: Scrollbar(
-                              child: ListView.builder(
-                                scrollDirection: Axis.horizontal,
-                                itemCount: storeImageUrls.length,
-                                itemBuilder: (context, index) {
-                                  return Padding(
-                                    padding: const EdgeInsets.only(left: 10),
-                                    child: ClipRRect(
-                                      borderRadius: BorderRadius.circular(0),
-                                      child: const ScalableImage(
-                                        height: 100,
-                                        width: 125,
-                                        // TODO(Kim): 各ストアのURLを表示する
-                                        photoUrl: '',
-                                      ),
+                            child: Column(
+                              children: [
+                                Padding(
+                                  padding: const EdgeInsets.only(
+                                    left: 10,
+                                    bottom: 5,
+                                  ),
+                                  child: Align(
+                                    alignment: Alignment.topLeft,
+                                    child: Text(
+                                      storeNames[shopNo],
+                                      style: context.textTheme.bodySmall,
                                     ),
-                                  );
-                                },
-                              ),
+                                  ),
+                                ),
+                                SizedBox(
+                                  height: 110,
+                                  child: Scrollbar(
+                                    child: ListView.builder(
+                                      scrollDirection: Axis.horizontal,
+                                      itemCount: storeImagesList[shopNo].length,
+                                      itemBuilder: (context, index) {
+                                        final photoUrl =
+                                            storeImagesList[shopNo][index];
+                                        return Padding(
+                                          padding:
+                                              const EdgeInsets.only(left: 10),
+                                          child: ClipRRect(
+                                            borderRadius:
+                                                BorderRadius.circular(8),
+                                            child: ScalableImage(
+                                              height: 100,
+                                              width: 125,
+                                              photoUrl: photoUrl,
+                                            ),
+                                          ),
+                                        );
+                                      },
+                                    ),
+                                  ),
+                                ),
+                              ],
                             ),
                           ),
+                          if (shopNo == shopNoSelected)
+                            Positioned(
+                              right: 0,
+                              top: 0,
+                              child: Container(
+                                width: 28,
+                                height: 28,
+                                decoration: const BoxDecoration(
+                                  color: Themes.mainOrange,
+                                  shape: BoxShape.circle,
+                                ),
+                                child: const Icon(
+                                  Icons.check,
+                                  color: Colors.white,
+                                  size: 20,
+                                ),
+                              ),
+                            ),
                         ],
                       ),
                     ),
-                    if (shopNo == shopNoSelected)
-                      Positioned(
-                        right: 0,
-                        top: 0,
-                        child: Container(
-                          width: 28,
-                          height: 28,
-                          decoration: const BoxDecoration(
-                            color: Themes.mainOrange,
-                            shape: BoxShape.circle,
-                          ),
-                          child: const Icon(
-                            Icons.check,
-                            color: Colors.white,
-                            size: 20,
+                  },
+                  const Gap(10),
+                  if (stores.length > 3)
+                    Align(
+                      alignment: Alignment.centerRight,
+                      child: TextButton(
+                        onPressed: () => showNextStores(setState),
+                        child: const Text(
+                          '次へ',
+                          style: TextStyle(
+                            color: Themes.gray,
                           ),
                         ),
                       ),
-                  ],
-                ),
-              },
-              const Gap(10),
-              const Align(
-                alignment: Alignment.centerRight,
-                child: Text('次の３店鋪'),
-              ),
-              const Gap(16),
-              Padding(
-                padding: EdgeInsets.symmetric(
-                  horizontal: context.screenWidth * 0.05,
-                ),
-                child: SizedBox(
-                  height: 44,
-                  child: CustomElevatedButton(
-                    onPressed: onSelected,
-                    text: '決定',
+                    ),
+                  const Gap(16),
+                  Padding(
+                    padding: EdgeInsets.symmetric(
+                      horizontal: context.screenWidth * 0.05,
+                    ),
+                    child: SizedBox(
+                      height: 44,
+                      child: CustomElevatedButton(
+                        onPressed: () async {
+                          // 決定ボタン押下時にstoreIdを更新
+                          await ref
+                              .read(photoControllerProvider)
+                              .updateStoreIdForPhoto(
+                                userId: userId,
+                                photoId: photoId,
+                                storeId: selectedStoreId,
+                              );
+                          onSelected();
+                        },
+                        text: '決定',
+                      ),
+                    ),
                   ),
-                ),
+                  const Spacer(),
+                ],
               ),
-              const Spacer(),
-            ],
-          ),
-        ),
+            ),
+          );
+        },
       );
     },
   );

--- a/lib/view/image_detail_page.dart
+++ b/lib/view/image_detail_page.dart
@@ -77,12 +77,21 @@ class _ImageDetailPageState extends ConsumerState<ImageDetailPage> {
 
   String formatAddress(String fullAddress) {
     final postalCodeIndex = fullAddress.indexOf('〒');
-    final postalCode = fullAddress.substring(
-      postalCodeIndex,
-      fullAddress.indexOf(' ', postalCodeIndex),
-    );
-    final address =
-        fullAddress.substring(fullAddress.indexOf(' ', postalCodeIndex) + 1);
+
+    // もし '〒' が見つからない場合、そのまま fullAddress を返す
+    if (postalCodeIndex == -1) {
+      return fullAddress;
+    }
+
+    // '〒' の次のスペースが見つからない場合、そのまま fullAddress を返す
+    final spaceIndex = fullAddress.indexOf(' ', postalCodeIndex);
+    if (spaceIndex == -1) {
+      return fullAddress;
+    }
+
+    final postalCode = fullAddress.substring(postalCodeIndex, spaceIndex);
+    final address = fullAddress.substring(spaceIndex + 1);
+
     return '$postalCode\n$address';
   }
 
@@ -127,13 +136,8 @@ class _ImageDetailPageState extends ConsumerState<ImageDetailPage> {
                         return Center(
                           child: Text('Error: ${storeSnapshot.error}'),
                         );
-                      } else if (!storeSnapshot.hasData ||
-                          storeSnapshot.data == null) {
-                        return const Center(
-                          child: Text('No store information available'),
-                        );
                       } else {
-                        final store = storeSnapshot.data!;
+                        final store = storeSnapshot.data;
                         return PageView.builder(
                           controller: _pageController,
                           itemCount: 1,
@@ -151,12 +155,12 @@ class _ImageDetailPageState extends ConsumerState<ImageDetailPage> {
                                 photoId: photo.id,
                                 areaStoreIds: photo.areaStoreIds,
                                 photoUrl: photo.url,
-                                storeName: store.name,
+                                storeName: store?.name ?? '',
                                 dateTime: DateTime.now(),
-                                address: formatAddress(store.address),
-                                storeUrl: store.website,
-                                storeImageUrls: store.imageUrls,
-                                storeOpeningHours: store.openingHours,
+                                address: formatAddress(store?.address ?? ''),
+                                storeUrl: store?.website ?? '',
+                                storeImageUrls: store?.imageUrls ?? [],
+                                storeOpeningHours: store?.openingHours ?? {},
                                 showCardBack: photo.storeId.isNotEmpty,
                                 onSelected: () {
                                   _downloadPhoto(ref);

--- a/lib/view/image_detail_page.dart
+++ b/lib/view/image_detail_page.dart
@@ -14,7 +14,6 @@ import 'image_detail/image_detail_card.dart';
 class ImageDetailPage extends ConsumerStatefulWidget {
   const ImageDetailPage({
     super.key,
-    // TODO: 不要なタイミングで削除
     required this.index,
     required this.photoId,
   });

--- a/lib/view/image_detail_page.dart
+++ b/lib/view/image_detail_page.dart
@@ -4,7 +4,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:go_router/go_router.dart';
 
 import '../core/themes.dart';
+import '../features/auth/auth_controller.dart';
 import '../features/photo/photo.dart';
+import '../features/photo/photo_controller.dart';
 import '../features/store/store.dart';
 import '../features/store/store_controller.dart';
 import 'image_detail/image_detail_card.dart';
@@ -14,14 +16,15 @@ class ImageDetailPage extends ConsumerStatefulWidget {
     super.key,
     // TODO(anyone): 不要なタイミングで削除
     required this.index,
-    required this.photo,
+    // required this.photo,
+    required this.photoId,
   });
 
   static const String routeName = '/image_detail';
   static const String routePath = '/image_detail';
 
   final int index;
-  final Photo photo;
+  final String photoId;
 
   @override
   ConsumerState<ImageDetailPage> createState() => _ImageDetailPageState();
@@ -29,21 +32,39 @@ class ImageDetailPage extends ConsumerStatefulWidget {
 
 class _ImageDetailPageState extends ConsumerState<ImageDetailPage> {
   late final PageController _pageController;
-  late Future<Store?> _storeFuture;
+  late Future<Photo?> _photo;
 
   @override
   void initState() {
     super.initState();
     _pageController =
         PageController(initialPage: widget.index, viewportFraction: 0.9);
-    _storeFuture = _fetchStore();
   }
 
-  Future<Store?> _fetchStore() async {
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    _downloadPhoto(ref);
+  }
+
+  void _downloadPhoto(WidgetRef ref) {
+    final userId = ref.watch(userIdProvider);
+
+    if (userId == null) {
+      return;
+    }
+
+    _photo = ref.read(photoControllerProvider).downloadPhoto(
+          userId: userId,
+          photoId: widget.photoId,
+        );
+  }
+
+  Future<Store?> _fetchStore(Photo photo) async {
     final storeController = ref.read(storeControllerProvider);
     final userId = FirebaseAuth.instance.currentUser!.uid;
 
-    final storeId = widget.photo.storeId;
+    final storeId = photo.storeId;
 
     if (storeId.isEmpty) {
       throw Exception('Store ID is null or empty');
@@ -57,6 +78,9 @@ class _ImageDetailPageState extends ConsumerState<ImageDetailPage> {
 
   @override
   Widget build(BuildContext context) {
+    // debugPrint('ImageDetailPage userId: ${widget.photo.userId}');
+    // debugPrint('ImageDetailPage photoId: ${widget.photo.id}');
+    // debugPrint('ImageDetailPage areaStoreIds: ${widget.photo.areaStoreIds}');
     return Scaffold(
       appBar: AppBar(
         backgroundColor: Colors.white,
@@ -75,8 +99,8 @@ class _ImageDetailPageState extends ConsumerState<ImageDetailPage> {
                 color: Themes.mainOrange[50],
               ),
             ),
-            FutureBuilder<Store?>(
-              future: _storeFuture,
+            FutureBuilder(
+              future: _photo,
               builder: (context, snapshot) {
                 if (snapshot.connectionState == ConnectionState.waiting) {
                   return const Center(child: CircularProgressIndicator());
@@ -87,26 +111,58 @@ class _ImageDetailPageState extends ConsumerState<ImageDetailPage> {
                     child: Text('No store information available'),
                   );
                 } else {
-                  final store = snapshot.data!;
-                  return PageView.builder(
-                    controller: _pageController,
-                    itemCount: 1,
-                    itemBuilder: (context, index) {
-                      return Padding(
-                        padding: EdgeInsets.only(
-                          top: MediaQuery.of(context).size.height * 0.01,
-                          bottom: MediaQuery.of(context).size.height * 0.01,
-                          left: 4,
-                          right: 4,
-                        ),
-                        child: ImageDetailCard(
-                            photoUrl: widget.photo.url,
-                            storeName: store.name,
-                            dateTime: DateTime.now(),
-                            address: store.address,
-                            storeUrl: store.website,
-                            storeImageUrls: store.imageUrls,),
-                      );
+                  final photo = snapshot.data;
+                  if (photo == null) {
+                    return const Center(
+                      child: Text('Nothing photo'),
+                    );
+                  }
+                  final storeFuture = _fetchStore(photo);
+
+                  return FutureBuilder<Store?>(
+                    future: storeFuture,
+                    builder: (context, snapshot) {
+                      if (snapshot.connectionState == ConnectionState.waiting) {
+                        return const Center(child: CircularProgressIndicator());
+                      } else if (snapshot.hasError) {
+                        return Center(child: Text('Error: ${snapshot.error}'));
+                      } else if (!snapshot.hasData || snapshot.data == null) {
+                        return const Center(
+                          child: Text('No store information available'),
+                        );
+                      } else {
+                        final store = snapshot.data!;
+                        return PageView.builder(
+                          controller: _pageController,
+                          itemCount: 1,
+                          itemBuilder: (context, index) {
+                            return Padding(
+                              padding: EdgeInsets.only(
+                                top: MediaQuery.of(context).size.height * 0.01,
+                                bottom:
+                                    MediaQuery.of(context).size.height * 0.01,
+                                left: 4,
+                                right: 4,
+                              ),
+                              child: ImageDetailCard(
+                                userId: photo.userId,
+                                photoId: photo.id,
+                                areaStoreIds: photo.areaStoreIds,
+                                photoUrl: photo.url,
+                                storeName: store.name,
+                                dateTime: DateTime.now(),
+                                address: store.address,
+                                storeUrl: store.website,
+                                storeImageUrls: store.imageUrls,
+                                onSelected: () {
+                                  _downloadPhoto(ref);
+                                  setState(() {});
+                                },
+                              ),
+                            );
+                          },
+                        );
+                      }
                     },
                   );
                 }

--- a/lib/view/widgets/navigation_frame.dart
+++ b/lib/view/widgets/navigation_frame.dart
@@ -23,7 +23,8 @@ class NavigationFrame extends ConsumerStatefulWidget {
 }
 
 class _NavigationFrameState extends ConsumerState<NavigationFrame> {
-  late int _selectedIndex;
+  // ギャラリーページから起動させる。
+  int _selectedIndex = 1;
 
   @override
   void initState() {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -393,14 +393,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.18.0"
-  exif:
-    dependency: "direct main"
-    description:
-      name: exif
-      sha256: a7980fdb3b7ffcd0b035e5b8a5e1eef7cadfe90ea6a4e85ebb62f87b96c7a172
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.3.0"
   fake_async:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,7 +18,6 @@ dependencies:
   cupertino_icons: ^1.0.2
   device_info_plus: ^10.1.0
   drift: ^2.15.0
-  exif: ^3.3.0
   firebase_analytics: any
   firebase_auth: any
   firebase_core: any


### PR DESCRIPTION
## 関連のタスク issue
<!-- Notionリンクを記載  -->
https://www.notion.so/masakisato/firestore-storeId-7bc55e9af86b4f2faf16c4fa49e37146?pvs=4

## 対応したこと
<!-- 実装の概要を箇条書きする  -->
- 店舗を選び直すを押下すると、店舗一覧が表示される。
- 店舗ホバー時にチェックマークが切り替わる。
- 決定ボタンで、firestoreのstoreIdが更新される。

## 未解決事項
<!-- 別PRで対応するような状況があれば記載  -->  
- 写真一覧で、枠をなぜか囲うことができない。

## 実際の挙動
<!-- UIに関わるようであればスクリーンショット、動きのあるものは動画 or GIF  -->  
<!-- 入力エリアにドラッグ&ドロップしてアップロード  -->

notionの動画を参照してください。

## チェックリスト
<!-- 空白を消して`x`をつける  -->  
- [x] 実装完了後、問題が起こっていないか実際に動作確認したか  
- [x] 補足があった方が良い/重点的にレビューが欲しい箇所にGitHub上でコメントをしたか

## その他コメント

<!-- 何かあれば！  -->
