### PR TITLE
起動時に一瞬エラー画面が出るのの修正

### DIFF
--- a/lib/view/widgets/navigation_frame.dart
+++ b/lib/view/widgets/navigation_frame.dart
@@ -23,7 +23,7 @@ class NavigationFrame extends ConsumerStatefulWidget {
 }
 
 class _NavigationFrameState extends ConsumerState<NavigationFrame> {
-  late int _selectedIndex;
+  late int _selectedIndex = 1;
 
   @override
   void initState() {


### PR DESCRIPTION
## 関連のタスク issue
なし

## 対応したこと
<!-- 実装の概要を箇条書きする  -->
- 起動時に一瞬エラー画面になり、「LateInitializationError: Field '_selectedIndex@120107851' has not been initialized.」のエラーが出ていたので、_selectedIndexに初期値を入れました。

## 未解決事項
<!-- 別PRで対応するような状況があれば記載  -->  

- なし

## 実際の挙動
<!-- UIに関わるようであればスクリーンショット、動きのあるものは動画 or GIF  -->  
<!-- 入力エリアにドラッグ&ドロップしてアップロード  -->

## チェックリスト
<!-- 空白を消して`x`をつける  -->  
- [x] 実装完了後、問題が起こっていないか実際に動作確認したか  
- [x] 補足があった方が良い/重点的にレビューが欲しい箇所にGitHub上でコメントをしたか

## その他コメント

<!-- 何かあれば！  -->
