### PR TITLE
fix カード画面のレイアウト（カード画面の余白を増やしiphoneSE

### DIFF
--- a/lib/view/image_detail/card_back.dart
+++ b/lib/view/image_detail/card_back.dart
@@ -233,7 +233,7 @@ class CardBack extends ConsumerWidget {
                   ),
                 ),
                 if (storeOpeningHours != null)
-                  Expanded(
+                  Flexible(
                     child: SingleChildScrollView(
                       child: Column(
                         crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/view/image_detail/card_back.dart
+++ b/lib/view/image_detail/card_back.dart
@@ -149,7 +149,7 @@ class CardBack extends ConsumerWidget {
                 ),
                 if (storeImageUrls.isNotEmpty)
                   SizedBox(
-                    height: 220,
+                    height: MediaQuery.of(context).size.height / 6,
                     child: Scrollbar(
                       child: ListView.builder(
                         scrollDirection: Axis.horizontal,
@@ -161,8 +161,8 @@ class CardBack extends ConsumerWidget {
                             child: ClipRRect(
                               borderRadius: BorderRadius.circular(8),
                               child: ScalablePhoto(
-                                height: 200,
-                                width: 200,
+                                height: MediaQuery.of(context).size.height / 6,
+                                width: MediaQuery.of(context).size.height / 6,
                                 photoUrl: photoUrl,
                               ),
                             ),

--- a/lib/view/image_detail_page.dart
+++ b/lib/view/image_detail_page.dart
@@ -103,6 +103,7 @@ class _ImageDetailPageState extends ConsumerState<ImageDetailPage> {
           icon: const Icon(Icons.arrow_back),
           onPressed: () => context.pop(),
         ),
+        toolbarHeight: 24,
       ),
       body: Center(
         child: Stack(


### PR DESCRIPTION
## 関連のタスク issue
<!-- Notionリンクを記載  -->
https://www.notion.so/masakisato/0e4aaaf3a9e04873aa6113c898fa9364?v=a97d99f44f0944eb95eeb2d0a0747550&p=8b82ea8a96a845e684b8dbca767ae527&pm=s

## 対応したこと
<!-- 実装の概要を箇条書きする  -->
◽️カード画面の余白を増やす。（iphoneSE時の営業時間の表示行数を増やすため。）
- カード画面で、appBarの高さを低くする。
- card_back.dartの画像を画面の1/6に変更


## 未解決事項
<!-- 別PRで対応するような状況があれば記載  -->  

- なし

## 実際の挙動
<!-- UIに関わるようであればスクリーンショット、動きのあるものは動画 or GIF  -->  
<!-- 入力エリアにドラッグ&ドロップしてアップロード  -->
iphoneSE・表
![スクリーンショット 2024-08-15 15 18 31](https://github.com/user-attachments/assets/4287cf94-927b-4463-b0fd-ac97b1cb6e78)

iphoneSE・裏
![スクリーンショット 2024-08-15 14 53 51](https://github.com/user-attachments/assets/221ee9e2-241f-4eb8-88d0-cf32ac7389cf)

iPhone15・表
![スクリーンショット 2024-08-15 15 25 31](https://github.com/user-attachments/assets/d8b908ba-7d78-4314-8d1e-e0dd076e6063)

iPhone15・裏
![スクリーンショット 2024-08-15 22 24 06](https://github.com/user-attachments/assets/8b031bfc-b881-4c90-a5f1-b2e02d0f8448)



## チェックリスト
<!-- 空白を消して`x`をつける  -->  
- [x] 実装完了後、問題が起こっていないか実際に動作確認したか  
- [x] 補足があった方が良い/重点的にレビューが欲しい箇所にGitHub上でコメントをしたか

## その他コメント
写真の下の余白は、調整しなくても問題なさそうだったので、そのままとしてみました。

<!-- 何かあれば！  -->
